### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   quality-gate:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/muend/arcgis-mcp-bridge/security/code-scanning/1](https://github.com/muend/arcgis-mcp-bridge/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (right after `on:` and before `jobs:`), setting:

- `contents: read`

This is the minimal, appropriate scope for the current workflow, and it applies to all jobs unless overridden. No functional behavior should change for the shown steps, but token privileges become explicitly restricted and documented.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
