### PR TITLE
build: add Docker smoke test image for MCP introspection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+build/
+*.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    ARCPY_PYTHON_PATH=/usr/local/bin/python \
+    ARCGIS_MCP_ALLOWED_ROOTS=/tmp/arcgis-mcp \
+    ARCGIS_MCP_SCRATCH_GDB=/tmp/arcgis-mcp/scratch.gdb \
+    ARCGIS_MCP_LOG_LEVEL=INFO \
+    ARCGIS_MCP_MAX_WORKERS=1
+
+RUN mkdir -p /tmp/arcgis-mcp/scratch.gdb
+
+COPY pyproject.toml README.md ./
+COPY arcgis_mcp ./arcgis_mcp
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir .
+
+CMD ["arcgis-mcp-server"]


### PR DESCRIPTION
Adds a minimal Docker image for MCP startup and introspection checks.

This image is intended for registry/Glama smoke testing only. It allows the stdio MCP server to start, expose its tool surface, and run the ArcPy-free health_check path.

Verified locally with MCP Inspector:
- server starts successfully
- tool list is exposed
- health_check returns success

Real ArcPy geoprocessing still requires licensed ArcGIS Pro Python on Windows and is not expected to run inside this Linux container.