### PR TITLE
docs: improve MCP tool definitions for Glama quality

### DIFF
--- a/arcgis_mcp/contracts/data_mgmt.py
+++ b/arcgis_mcp/contracts/data_mgmt.py
@@ -15,18 +15,46 @@ EsriFieldType = Literal[
 
 
 class DatasetInput(ToolInput):
-    """Shared base: tools reading one existing dataset/table."""
+    """Shared base for tools that read one existing GIS dataset or table."""
 
-    dataset: str = Field(..., min_length=1, description="Absolute dataset path.")
+    dataset: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path to an existing feature class, table, raster, or "
+            "geodatabase item. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"dataset": "read"}
 
 
 class InOutInput(ToolInput):
-    """Shared base: one input dataset, one output dataset."""
+    """Shared base for tools that read one dataset and create one output."""
 
-    in_features: str = Field(..., min_length=1)
-    out_features: str = Field(..., min_length=1)
-    overwrite: bool = False
+    in_features: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path to the existing input feature class, layer, or table. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute output dataset path to create. The path must be inside a "
+            "configured PathGuard allowed root; existing outputs require "
+            "overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output dataset is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_features": "write",
@@ -34,45 +62,133 @@ class InOutInput(ToolInput):
 
 
 class CreateFeatureClassInput(ToolInput):
-    out_gdb: str = Field(..., description="Existing .gdb to create the FC in.")
-    name: str = Field(..., pattern=r"^[A-Za-z_][A-Za-z0-9_]*$", max_length=160)
-    geometry_type: EsriGeometry = "POLYGON"
+    """Create an empty feature class inside an existing file geodatabase."""
+
+    out_gdb: str = Field(
+        ...,
+        description=(
+            "Absolute path to an existing file geodatabase where the new feature "
+            "class will be created. The geodatabase must be inside a configured "
+            "PathGuard allowed root."
+        ),
+    )
+    name: str = Field(
+        ...,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+        max_length=160,
+        description=(
+            "Name of the new feature class, without a path. Use a valid ArcGIS "
+            "dataset name beginning with a letter or underscore."
+        ),
+    )
+    geometry_type: EsriGeometry = Field(
+        default="POLYGON",
+        description=(
+            "Geometry type for the new feature class: POINT, MULTIPOINT, "
+            "POLYLINE, POLYGON, or MULTIPATCH."
+        ),
+    )
     wkid: Optional[int] = Field(
         default=None,
         ge=1024,
         le=32767 + 200000,
-        description="Spatial reference WKID, e.g. 4326. None = unknown CRS.",
+        description=(
+            "Optional spatial reference WKID, for example 4326 for WGS 84. "
+            "Use None to create the feature class with an unknown coordinate system."
+        ),
     )
-    overwrite: bool = False
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing feature class with the same "
+            "name is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"out_gdb": "read"}
 
 
 class DeleteDatasetInput(DatasetInput):
+    """Delete an existing dataset; irreversible and confirmation-gated."""
+
     confirm: bool = Field(
-        default=False, description="Must be true: deletion is irreversible."
+        default=False,
+        description=(
+            "Must be true. Deleting a dataset is irreversible and removes the "
+            "target feature class, table, raster, or geodatabase item."
+        ),
     )
 
 
 class CopyFeaturesInput(InOutInput):
-    pass
+    """Copy a feature class or layer into a new output feature class."""
 
 
 class RenameDatasetInput(DatasetInput):
-    new_name: str = Field(..., pattern=r"^[A-Za-z_][A-Za-z0-9_]*$", max_length=160)
+    """Rename an existing dataset within its current workspace."""
+
+    new_name: str = Field(
+        ...,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+        max_length=160,
+        description=(
+            "New dataset name only, not a full path. Use a valid ArcGIS name "
+            "beginning with a letter or underscore."
+        ),
+    )
 
 
 class AddFieldInput(DatasetInput):
-    field_name: str = Field(..., pattern=r"^[A-Za-z_][A-Za-z0-9_]*$", max_length=64)
-    field_type: EsriFieldType = "TEXT"
-    length: Optional[int] = Field(
-        default=None, ge=1, le=2147483647, description="TEXT length; ignored otherwise."
+    """Add one attribute field to an existing table or feature class."""
+
+    field_name: str = Field(
+        ...,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+        max_length=64,
+        description=(
+            "Name of the field to add. Use a valid ArcGIS field name beginning "
+            "with a letter or underscore."
+        ),
     )
-    alias: Optional[str] = None
+    field_type: EsriFieldType = Field(
+        default="TEXT",
+        description=(
+            "ArcGIS field type to create, such as TEXT, LONG, DOUBLE, DATE, "
+            "GUID, or BLOB."
+        ),
+    )
+    length: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=2147483647,
+        description=(
+            "Optional text field length. Used for TEXT fields and ignored by "
+            "most numeric, date, GUID, and BLOB field types."
+        ),
+    )
+    alias: Optional[str] = Field(
+        default=None,
+        description="Optional human-readable field alias shown in ArcGIS.",
+    )
 
 
 class DeleteFieldInput(DatasetInput):
-    fields: List[str] = Field(..., min_length=1)
-    confirm: bool = Field(default=False, description="Must be true: drops data.")
+    """Delete one or more fields from an existing table or feature class."""
+
+    fields: List[str] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "List of field names to delete from the dataset. System-required "
+            "fields cannot be deleted by ArcGIS."
+        ),
+    )
+    confirm: bool = Field(
+        default=False,
+        description=(
+            "Must be true. Dropping fields permanently removes attribute data "
+            "from the input dataset."
+        ),
+    )
 
 
 class CalculateFieldInput(DatasetInput):
@@ -87,9 +203,33 @@ class CalculateFieldInput(DatasetInput):
     dispatcher's destructive-tool gate (Layer B, trust no parent).
     """
 
-    field_name: str = Field(..., min_length=1, max_length=64)
-    expression: str = Field(..., min_length=1, max_length=4000)
-    expression_type: Literal["PYTHON3", "ARCADE", "SQL"] = "ARCADE"
+    field_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Name of the existing field whose values will be calculated. "
+            "The field must already exist in the input dataset."
+        ),
+    )
+    expression: str = Field(
+        ...,
+        min_length=1,
+        max_length=4000,
+        description=(
+            "Calculation expression passed to ArcPy CalculateField. Prefer "
+            "ARCADE for LLM-facing workflows because it is sandboxed compared "
+            "with PYTHON3."
+        ),
+    )
+    expression_type: Literal["PYTHON3", "ARCADE", "SQL"] = Field(
+        default="ARCADE",
+        description=(
+            "Expression language for the calculation. ARCADE is the default "
+            "safer option. PYTHON3 executes Python code in the worker and "
+            "requires confirm=true."
+        ),
+    )
     confirm: bool = Field(
         default=False,
         description=(
@@ -111,45 +251,115 @@ class CalculateFieldInput(DatasetInput):
 
 
 class FieldDef(BaseModel):
-    """One field for the batch AddFields call."""
+    """One field definition for the batch AddFields call."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
-    name: str = Field(..., pattern=r"^[A-Za-z_][A-Za-z0-9_]*$", max_length=64)
-    type: EsriFieldType = "TEXT"
-    length: Optional[int] = Field(default=None, ge=1)
-    alias: Optional[str] = None
+
+    name: str = Field(
+        ...,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+        max_length=64,
+        description=(
+            "Name of the field to add. Use a valid ArcGIS field name beginning "
+            "with a letter or underscore."
+        ),
+    )
+    type: EsriFieldType = Field(
+        default="TEXT",
+        description="ArcGIS field type to create, such as TEXT, LONG, DOUBLE, or DATE.",
+    )
+    length: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Optional text field length. Primarily used when type is TEXT."
+        ),
+    )
+    alias: Optional[str] = Field(
+        default=None,
+        description="Optional human-readable field alias shown in ArcGIS.",
+    )
 
 
 class AddFieldsBatchInput(DatasetInput):
-    fields: List[FieldDef] = Field(..., min_length=1, max_length=100)
+    """Add multiple fields to an existing table or feature class."""
+
+    fields: List[FieldDef] = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description=(
+            "Field definitions to add in one ArcPy AddFields operation. Each "
+            "definition includes a name, type, optional alias, and optional length."
+        ),
+    )
 
 
 class GetFieldInfoInput(DatasetInput):
-    pass
+    """List field names, types, lengths, aliases, and nullable status."""
 
 
 class GetFeatureCountInput(DatasetInput):
-    pass
+    """Return the row or feature count for an existing dataset."""
 
 
 class DescribeDatasetInput(DatasetInput):
-    pass
+    """Return dataset metadata such as data type, geometry type, CRS, and extent."""
 
 
 class CreateFileGdbInput(ToolInput):
-    parent_folder: str = Field(..., description="Existing folder for the new .gdb.")
-    gdb_name: str = Field(..., pattern=r"^[A-Za-z_][A-Za-z0-9_]*$", max_length=100)
+    """Create a new file geodatabase in an existing folder."""
+
+    parent_folder: str = Field(
+        ...,
+        description=(
+            "Absolute path to an existing folder where the new file geodatabase "
+            "will be created. The folder must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    gdb_name: str = Field(
+        ...,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+        max_length=100,
+        description=(
+            "Name of the new file geodatabase, without a path. Use a valid "
+            "geodatabase name such as analysis_scratch."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"parent_folder": "read"}
 
 
 class CompactGdbInput(ToolInput):
-    gdb: str = Field(..., description="Path to the .gdb to compact.")
+    """Compact an existing file geodatabase to reclaim space."""
+
+    gdb: str = Field(
+        ...,
+        description=(
+            "Absolute path to the existing file geodatabase to compact. The "
+            "geodatabase must be inside a configured PathGuard allowed root."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"gdb": "read"}
 
 
 class ExportToShapefileInput(ToolInput):
-    in_features: str
-    output_folder: str = Field(..., description="Existing destination folder.")
+    """Export a feature class to shapefile format in an existing folder."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class or layer to export. The "
+            "path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    output_folder: str = Field(
+        ...,
+        description=(
+            "Existing destination folder for the shapefile output. The folder "
+            "must be inside a configured PathGuard allowed root."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "output_folder": "read",
@@ -157,9 +367,26 @@ class ExportToShapefileInput(ToolInput):
 
 
 class ExportToGeojsonInput(ToolInput):
-    in_features: str
-    out_json: str = Field(..., description="Output .geojson path.")
-    overwrite: bool = False
+    """Export features to a GeoJSON file in WGS84."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class or layer to export as "
+            "GeoJSON. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_json: str = Field(
+        ...,
+        description=(
+            "Absolute output .geojson file path to create. Existing files "
+            "require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing GeoJSON file is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_json": "write",
@@ -167,9 +394,28 @@ class ExportToGeojsonInput(ToolInput):
 
 
 class ImportFromGeojsonInput(ToolInput):
-    in_json: str
-    out_features: str
-    overwrite: bool = False
+    """Convert a GeoJSON file into an ArcGIS feature class."""
+
+    in_json: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input .geojson file to convert. The file must "
+            "be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create from the GeoJSON. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_json": "read",
         "out_features": "write",
@@ -177,9 +423,27 @@ class ImportFromGeojsonInput(ToolInput):
 
 
 class TableToExcelInput(ToolInput):
-    table: str
-    out_xlsx: str
-    overwrite: bool = False
+    """Export an attribute table to an Excel workbook."""
+
+    table: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input table or feature class whose attributes "
+            "will be exported. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    out_xlsx: str = Field(
+        ...,
+        description=(
+            "Absolute output .xlsx path to create. Existing files require "
+            "overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing Excel file is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "table": "read",
         "out_xlsx": "write",
@@ -187,10 +451,35 @@ class TableToExcelInput(ToolInput):
 
 
 class ExcelToTableInput(ToolInput):
-    in_xlsx: str
-    out_table: str
-    sheet: Optional[str] = None
-    overwrite: bool = False
+    """Import an Excel worksheet into a geodatabase table."""
+
+    in_xlsx: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input .xlsx workbook. The file must be inside "
+            "a configured PathGuard allowed root."
+        ),
+    )
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output geodatabase table path to create. Existing outputs "
+            "require overwrite=true."
+        ),
+    )
+    sheet: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional worksheet name to import. Use None to let ArcPy choose the "
+            "default sheet."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output table is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_xlsx": "read",
         "out_table": "write",
@@ -198,9 +487,26 @@ class ExcelToTableInput(ToolInput):
 
 
 class FeatureToCsvInput(ToolInput):
-    in_table: str
-    out_csv: str = Field(..., description="Output .csv path.")
-    overwrite: bool = False
+    """Export a feature class or table to a CSV file."""
+
+    in_table: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class or table whose rows will "
+            "be exported. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_csv: str = Field(
+        ...,
+        description=(
+            "Absolute output .csv file path to create. Existing files require "
+            "overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing CSV file is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_table": "read",
         "out_csv": "write",
@@ -208,7 +514,7 @@ class FeatureToCsvInput(ToolInput):
 
 
 class GetExtentInput(DatasetInput):
-    pass
+    """Return xmin, ymin, xmax, ymax, and CRS metadata for a dataset extent."""
 
 
 GeometryProperty = Literal[
@@ -226,11 +532,38 @@ GeometryProperty = Literal[
 
 
 class CalculateGeometryInput(DatasetInput):
-    field_name: str = Field(..., max_length=64)
-    geometry_property: GeometryProperty
-    area_unit: Optional[str] = Field(default=None, description="e.g. SQUARE_METERS")
-    length_unit: Optional[str] = Field(default=None, description="e.g. METERS")
+    """Calculate area, length, perimeter, centroid, or point coordinate attributes."""
+
+    field_name: str = Field(
+        ...,
+        max_length=64,
+        description=(
+            "Existing or target field name that will receive the calculated "
+            "geometry value."
+        ),
+    )
+    geometry_property: GeometryProperty = Field(
+        ...,
+        description=(
+            "Geometry property to calculate, such as AREA, LENGTH, CENTROID_X, "
+            "CENTROID_Y, POINT_X, or POINT_Y."
+        ),
+    )
+    area_unit: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional area unit for area calculations, for example SQUARE_METERS. "
+            "Ignored for non-area geometry properties."
+        ),
+    )
+    length_unit: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional length unit for length or perimeter calculations, for example "
+            "METERS. Ignored for non-length geometry properties."
+        ),
+    )
 
 
 class AddXyCoordinatesInput(DatasetInput):
-    pass
+    """Add or update POINT_X and POINT_Y coordinate fields on point features."""

--- a/arcgis_mcp/contracts/editing_topology.py
+++ b/arcgis_mcp/contracts/editing_topology.py
@@ -10,16 +10,39 @@ from .base import PathRole, ToolInput
 
 
 class AppendFeaturesInput(ToolInput):
-    """Append rows from one or more FCs into an existing target (mutates it)."""
+    """Append rows from one or more feature classes into an existing target."""
 
-    inputs: List[str] = Field(..., min_length=1, max_length=20)
-    target: str = Field(..., description="Existing FC that receives the rows.")
+    inputs: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=20,
+        description=(
+            "Absolute paths to one or more input feature classes or tables whose "
+            "rows will be appended. Every path must be inside a configured "
+            "PathGuard allowed root."
+        ),
+    )
+    target: str = Field(
+        ...,
+        description=(
+            "Absolute path to the existing target feature class or table that "
+            "will receive the appended rows. This dataset is modified in place "
+            "and must be inside a configured PathGuard allowed root."
+        ),
+    )
     schema_type: Literal["TEST", "NO_TEST"] = Field(
         default="TEST",
-        description="TEST = schemas must match; NO_TEST = best-effort mapping.",
+        description=(
+            "Schema validation mode for ArcPy Append. TEST requires compatible "
+            "schemas; NO_TEST allows best-effort field mapping where ArcPy supports it."
+        ),
     )
     confirm: bool = Field(
-        default=False, description="Must be true: appends into live data."
+        default=False,
+        description=(
+            "Must be true. append_features mutates the target dataset by inserting "
+            "rows from the input datasets."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "inputs": "read_list",
@@ -28,24 +51,53 @@ class AppendFeaturesInput(ToolInput):
 
 
 class RepairGeometryInput(ToolInput):
-    """Repair invalid geometries IN PLACE (RepairGeometry)."""
+    """Repair invalid geometries in place using ArcPy RepairGeometry."""
 
-    in_features: str
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class whose invalid geometries will be "
+            "repaired in place. Use a copied working dataset when possible."
+        ),
+    )
     delete_null: bool = Field(
-        default=True, description="True deletes features with null geometry."
+        default=True,
+        description=(
+            "When true, delete features with null geometry during repair. When "
+            "false, keep null-geometry features where ArcPy allows it."
+        ),
     )
     confirm: bool = Field(
-        default=False, description="Must be true: rewrites geometries in place."
+        default=False,
+        description=(
+            "Must be true. repair_geometry rewrites feature geometries in the "
+            "input dataset and may delete null-geometry rows."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {"in_features": "read"}
 
 
 class CheckGeometryInput(ToolInput):
-    """Report (not fix) geometry problems into a table (CheckGeometry)."""
+    """Report geometry problems to an output table without modifying features."""
 
-    in_features: str
-    out_table: str
-    overwrite: bool = False
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class whose geometry will be checked. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output table path where geometry problems will be written. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output table is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_table": "write",
@@ -53,11 +105,42 @@ class CheckGeometryInput(ToolInput):
 
 
 class DetectFeatureChangesInput(ToolInput):
-    update_features: str = Field(..., description="The newer dataset.")
-    base_features: str = Field(..., description="The reference dataset.")
-    out_features: str
-    search_distance: str = Field(..., description="Match tolerance, e.g. '5 Meters'.")
-    overwrite: bool = False
+    """Detect changed features by comparing a newer dataset against a reference."""
+
+    update_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the newer or updated feature dataset being compared. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    base_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the reference or baseline feature dataset. The path "
+            "must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create with detected feature "
+            "changes. Existing outputs require overwrite=true."
+        ),
+    )
+    search_distance: str = Field(
+        ...,
+        description=(
+            "Feature matching tolerance with units, for example '5 Meters'. Use "
+            "a value appropriate to the dataset precision and expected geometry shift."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output change dataset is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "update_features": "read",
         "base_features": "read",
@@ -66,33 +149,98 @@ class DetectFeatureChangesInput(ToolInput):
 
 
 class DeleteIdenticalInput(ToolInput):
-    """Delete duplicate rows IN PLACE by field/geometry equality."""
+    """Delete duplicate rows in place by field or geometry equality."""
 
-    dataset: str
+    dataset: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class or table where duplicate rows "
+            "will be removed in place. Use a copied working dataset when possible."
+        ),
+    )
     fields: List[str] = Field(
         ...,
         min_length=1,
-        description="Comparison fields; use 'Shape' for geometry equality.",
+        description=(
+            "Comparison fields used to identify duplicate rows. Use 'Shape' when "
+            "geometry equality should be part of the duplicate test."
+        ),
     )
     xy_tolerance: Optional[str] = Field(
-        default=None, description="e.g. '0.01 Meters' (geometry comparisons)."
+        default=None,
+        description=(
+            "Optional XY tolerance for geometry comparisons, for example "
+            "'0.01 Meters'. Use None to let ArcPy use its default tolerance."
+        ),
     )
     confirm: bool = Field(
-        default=False, description="Must be true: deletes rows irreversibly."
+        default=False,
+        description=(
+            "Must be true. delete_identical irreversibly removes duplicate rows "
+            "from the input dataset."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {"dataset": "read"}
 
 
 class EliminatePolygonPartInput(ToolInput):
-    in_features: str
-    out_features: str
-    condition: Literal["AREA", "PERCENT", "AREA_OR_PERCENT", "AREA_AND_PERCENT"] = (
-        "AREA"
+    """Remove small polygon holes or parts and write a cleaned output feature class."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input polygon feature class to clean. The path "
+            "must be inside a configured PathGuard allowed root."
+        ),
     )
-    part_area: float = Field(default=0.0, ge=0.0, description="Map-unit area.")
-    part_area_percent: float = Field(default=0.0, ge=0.0, le=100.0)
-    eliminate_contained_parts_only: bool = True
-    overwrite: bool = False
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output polygon feature class path to create after eliminating "
+            "small parts. Existing outputs require overwrite=true."
+        ),
+    )
+    condition: Literal["AREA", "PERCENT", "AREA_OR_PERCENT", "AREA_AND_PERCENT"] = (
+        Field(
+            default="AREA",
+            description=(
+                "Rule used to decide which polygon parts are eliminated. AREA uses "
+                "part_area, PERCENT uses part_area_percent, and combined options "
+                "apply either or both thresholds."
+            ),
+        )
+    )
+    part_area: float = Field(
+        default=0.0,
+        ge=0.0,
+        description=(
+            "Area threshold in map units. Polygon parts smaller than this threshold "
+            "may be eliminated depending on condition."
+        ),
+    )
+    part_area_percent: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=100.0,
+        description=(
+            "Percentage threshold from 0 to 100. Polygon parts below this percentage "
+            "may be eliminated depending on condition."
+        ),
+    )
+    eliminate_contained_parts_only: bool = Field(
+        default=True,
+        description=(
+            "When true, eliminate only contained polygon parts such as holes. When "
+            "false, allow ArcPy to eliminate qualifying parts more broadly."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing cleaned output feature class "
+            "is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_features": "write",
@@ -100,11 +248,21 @@ class EliminatePolygonPartInput(ToolInput):
 
 
 class TopologyCheckInput(ToolInput):
-    """Validate a geodatabase topology (ValidateTopology)."""
+    """Validate a geodatabase topology using ArcPy ValidateTopology."""
 
-    in_topology: str = Field(..., description="Path to the GDB topology.")
+    in_topology: str = Field(
+        ...,
+        description=(
+            "Absolute path to the geodatabase topology to validate. The topology "
+            "must be inside a configured PathGuard allowed root."
+        ),
+    )
     visible_extent: bool = Field(
-        default=False, description="False validates the full extent."
+        default=False,
+        description=(
+            "When false, validate the full topology extent. When true, request "
+            "visible-extent validation where the ArcPy topology context supports it."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {"in_topology": "read"}
 

--- a/arcgis_mcp/contracts/export_layout.py
+++ b/arcgis_mcp/contracts/export_layout.py
@@ -11,31 +11,70 @@ from .map_mgmt import AprxInput
 
 
 class LayoutScopedInput(AprxInput):
-    """Shared base: tools that target one layout inside the project."""
+    """Shared base for tools that target one layout inside an ArcGIS Pro project."""
 
     layout_name: Optional[str] = Field(
-        default=None, description="Layout name; None targets the first layout."
+        default=None,
+        description=(
+            "Name of the layout inside the .aprx project. Use None to target the "
+            "first layout returned by ArcGIS Pro."
+        ),
     )
 
 
 class MapFrameScopedInput(LayoutScopedInput):
-    """Shared base: tools that target one map frame inside one layout."""
+    """Shared base for tools that target one map frame inside one layout."""
 
     map_frame: Optional[str] = Field(
-        default=None, description="Map frame name; None targets the first frame."
+        default=None,
+        description=(
+            "Name of the map frame inside the selected layout. Use None to target "
+            "the first map frame in that layout."
+        ),
     )
-    save: bool = True
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after applying the layout or map "
+            "frame change. Use false for temporary changes before export."
+        ),
+    )
 
 
 class ListLayoutsInput(AprxInput):
-    pass
+    """List layouts available in an ArcGIS Pro project without modifying it."""
 
 
 class ExportLayoutPdfInput(LayoutScopedInput):
-    out_pdf: str = Field(..., description="Output .pdf path.")
-    resolution: int = Field(default=300, ge=72, le=1200, description="DPI.")
-    image_quality: Literal["BEST", "BETTER", "NORMAL", "FASTER", "FASTEST"] = "BEST"
-    overwrite: bool = False
+    """Export a selected layout from an ArcGIS Pro project to a PDF file."""
+
+    out_pdf: str = Field(
+        ...,
+        description=(
+            "Absolute output .pdf path to create. The path must be inside a "
+            "configured PathGuard allowed root; existing files require overwrite=true."
+        ),
+    )
+    resolution: int = Field(
+        default=300,
+        ge=72,
+        le=1200,
+        description=(
+            "Export resolution in DPI. Use 300 for print-quality output, lower "
+            "values for faster preview exports, and higher values for detailed maps."
+        ),
+    )
+    image_quality: Literal["BEST", "BETTER", "NORMAL", "FASTER", "FASTEST"] = Field(
+        default="BEST",
+        description=(
+            "PDF image quality setting passed to ArcGIS Pro layout export. BEST "
+            "prioritizes quality; FASTER and FASTEST prioritize speed and smaller files."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing PDF file is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "aprx_path": "read",
         "out_pdf": "write",
@@ -43,10 +82,35 @@ class ExportLayoutPdfInput(LayoutScopedInput):
 
 
 class ExportLayoutPngInput(LayoutScopedInput):
-    out_png: str = Field(..., description="Output .png path.")
-    resolution: int = Field(default=300, ge=72, le=1200, description="DPI.")
-    transparent_background: bool = False
-    overwrite: bool = False
+    """Export a selected layout from an ArcGIS Pro project to a PNG image."""
+
+    out_png: str = Field(
+        ...,
+        description=(
+            "Absolute output .png path to create. The path must be inside a "
+            "configured PathGuard allowed root; existing files require overwrite=true."
+        ),
+    )
+    resolution: int = Field(
+        default=300,
+        ge=72,
+        le=1200,
+        description=(
+            "Export resolution in DPI. Use 300 for print-quality layout images "
+            "and lower values for quick previews."
+        ),
+    )
+    transparent_background: bool = Field(
+        default=False,
+        description=(
+            "When true, export the PNG with a transparent background where the "
+            "layout supports transparency."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing PNG file is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "aprx_path": "read",
         "out_png": "write",
@@ -54,16 +118,47 @@ class ExportLayoutPngInput(LayoutScopedInput):
 
 
 class ExportMapAsImageInput(AprxInput):
-    """Export a map view directly (no layout) via its default view."""
+    """Export a map view directly as a PNG image without using a layout."""
 
     map_name: Optional[str] = Field(
-        default=None, description="Map name; None targets the first map."
+        default=None,
+        description=(
+            "Name of the map inside the .aprx project. Use None to target the "
+            "first map returned by ArcGIS Pro."
+        ),
     )
-    out_png: str = Field(..., description="Output .png path.")
-    width: int = Field(default=1920, ge=64, le=10000, description="Pixels.")
-    height: int = Field(default=1080, ge=64, le=10000, description="Pixels.")
-    resolution: int = Field(default=96, ge=72, le=600, description="DPI.")
-    overwrite: bool = False
+    out_png: str = Field(
+        ...,
+        description=(
+            "Absolute output .png path to create. The path must be inside a "
+            "configured PathGuard allowed root; existing files require overwrite=true."
+        ),
+    )
+    width: int = Field(
+        default=1920,
+        ge=64,
+        le=10000,
+        description="Output image width in pixels.",
+    )
+    height: int = Field(
+        default=1080,
+        ge=64,
+        le=10000,
+        description="Output image height in pixels.",
+    )
+    resolution: int = Field(
+        default=96,
+        ge=72,
+        le=600,
+        description=(
+            "Export resolution in DPI. Use 96 for screen-oriented exports and "
+            "higher values for sharper map images."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing PNG file is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "aprx_path": "read",
         "out_png": "write",
@@ -71,33 +166,108 @@ class ExportMapAsImageInput(AprxInput):
 
 
 class SetMapScaleInput(MapFrameScopedInput):
-    scale: float = Field(..., gt=0, description="Denominator, e.g. 1000 for 1:1000.")
+    """Set the map scale denominator for a selected map frame."""
+
+    scale: float = Field(
+        ...,
+        gt=0,
+        description=(
+            "Scale denominator for the target map frame, for example 1000 for "
+            "1:1000 or 50000 for 1:50,000."
+        ),
+    )
 
 
 class SetMapExtentFromLayerInput(MapFrameScopedInput):
-    layer_name: str = Field(..., min_length=1)
+    """Set a map frame extent to match the extent of a named layer."""
+
+    layer_name: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Name of the layer whose extent will be used to update the selected "
+            "map frame. The layer must exist in the map connected to that frame."
+        ),
+    )
 
 
 class UpdateTextElementInput(LayoutScopedInput):
-    element_name: str = Field(..., min_length=1, description="Text element name.")
-    new_text: str = Field(..., min_length=0, max_length=10000)
-    save: bool = True
+    """Update the text content of a named layout text element."""
+
+    element_name: str = Field(
+        ...,
+        min_length=1,
+        description="Name of the text element to update in the selected layout.",
+    )
+    new_text: str = Field(
+        ...,
+        min_length=0,
+        max_length=10000,
+        description=(
+            "New text content to write into the layout element. Use an empty "
+            "string to clear the element."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after updating the text element."
+        ),
+    )
 
 
 class UpdateLegendInput(LayoutScopedInput):
+    """Add or remove a layer entry in a selected layout legend."""
+
     legend_name: Optional[str] = Field(
-        default=None, description="Legend element name; None targets the first."
+        default=None,
+        description=(
+            "Name of the legend element to update. Use None to target the first "
+            "legend in the selected layout."
+        ),
     )
-    layer_name: str = Field(..., min_length=1)
-    action: Literal["ADD", "REMOVE"] = "ADD"
-    map_frame: Optional[str] = None
-    save: bool = True
+    layer_name: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Name of the layer to add to or remove from the legend. The layer "
+            "must exist in the target map frame."
+        ),
+    )
+    action: Literal["ADD", "REMOVE"] = Field(
+        default="ADD",
+        description="Legend operation to perform: ADD the layer or REMOVE it.",
+    )
+    map_frame: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional map frame name used to resolve the layer. Use None to target "
+            "the first map frame in the selected layout."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description="When true, save the .aprx project after updating the legend.",
+    )
 
 
 class SetLayoutSizeInput(LayoutScopedInput):
-    page_width: float = Field(..., gt=0, description="In the layout's page units.")
-    page_height: float = Field(..., gt=0)
-    save: bool = True
+    """Set the physical page size of a selected layout."""
+
+    page_width: float = Field(
+        ...,
+        gt=0,
+        description="New layout page width in the layout's current page units.",
+    )
+    page_height: float = Field(
+        ...,
+        gt=0,
+        description="New layout page height in the layout's current page units.",
+    )
+    save: bool = Field(
+        default=True,
+        description="When true, save the .aprx project after resizing the layout.",
+    )
 
 
 __all__ = [

--- a/arcgis_mcp/contracts/geometry.py
+++ b/arcgis_mcp/contracts/geometry.py
@@ -11,11 +11,31 @@ from .data_mgmt import InOutInput
 
 
 class MultiInputOverlay(ToolInput):
-    """Shared base: N input layers -> one output (Intersect, Union, Merge)."""
+    """Shared base for overlay tools that read multiple inputs and write one output."""
 
-    in_features: List[str] = Field(..., min_length=2, max_length=20)
-    out_features: str
-    overwrite: bool = False
+    in_features: List[str] = Field(
+        ...,
+        min_length=2,
+        max_length=20,
+        description=(
+            "Absolute paths to two or more existing input feature classes or "
+            "layers. Every path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create from the overlay result. "
+            "The path must be inside a configured PathGuard allowed root; existing "
+            "outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read_list",
         "out_features": "write",
@@ -23,12 +43,36 @@ class MultiInputOverlay(ToolInput):
 
 
 class TwoLayerOverlay(ToolInput):
-    """Shared base: primary + secondary layer -> output (Erase, Identity...)."""
+    """Shared base for tools that overlay one primary layer with one secondary layer."""
 
-    in_features: str
-    overlay_features: str
-    out_features: str
-    overwrite: bool = False
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the primary input feature class or layer. The path "
+            "must be inside a configured PathGuard allowed root."
+        ),
+    )
+    overlay_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the secondary overlay feature class or layer. The "
+            "path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create. The path must be inside "
+            "a configured PathGuard allowed root; existing outputs require "
+            "overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "overlay_features": "read",
@@ -37,32 +81,63 @@ class TwoLayerOverlay(ToolInput):
 
 
 class IntersectFeaturesInput(MultiInputOverlay):
-    join_attributes: Literal["ALL", "NO_FID", "ONLY_FID"] = "ALL"
+    """Input contract for creating the shared geometry of multiple feature layers."""
+
+    join_attributes: Literal["ALL", "NO_FID", "ONLY_FID"] = Field(
+        default="ALL",
+        description=(
+            "Attribute transfer mode for ArcPy Intersect. ALL keeps all input "
+            "attributes, NO_FID drops feature ID fields, and ONLY_FID keeps only "
+            "feature ID fields."
+        ),
+    )
 
 
 class UnionFeaturesInput(MultiInputOverlay):
-    pass
+    """Input contract for polygon union overlay."""
 
 
 class EraseFeaturesInput(TwoLayerOverlay):
-    pass
+    """Input contract for subtracting overlay features from primary features."""
 
 
 class DissolveFeaturesInput(InOutInput):
-    dissolve_fields: List[str] = Field(default_factory=list, max_length=20)
-    multi_part: bool = True
+    """Input contract for dissolving features by shared attribute values."""
+
+    dissolve_fields: List[str] = Field(
+        default_factory=list,
+        max_length=20,
+        description=(
+            "Optional field names used to group features before dissolving. Use an "
+            "empty list to dissolve all input features into one multipart or "
+            "singlepart output."
+        ),
+    )
+    multi_part: bool = Field(
+        default=True,
+        description=(
+            "When true, allow multipart output features. When false, force "
+            "singlepart output where ArcPy supports it."
+        ),
+    )
 
 
 class MergeFeaturesInput(MultiInputOverlay):
-    pass
+    """Input contract for merging multiple compatible feature layers."""
 
 
 class SelectByAttributeInput(InOutInput):
+    """Input contract for materializing a SQL attribute selection."""
+
     where_clause: str = Field(
         ...,
         min_length=1,
         max_length=4000,
-        description='SQL expression, e.g. "POP > 1000".',
+        description=(
+            'SQL expression used to select rows, for example "POP > 1000". '
+            "The expression is passed to ArcPy Select and should match the input "
+            "workspace SQL dialect."
+        ),
     )
 
 
@@ -81,15 +156,58 @@ SpatialRelationship = Literal[
 
 
 class SelectByLocationInput(ToolInput):
-    in_features: str
-    select_features: str
-    out_features: str
-    relationship: SpatialRelationship = "INTERSECT"
-    search_distance: Optional[str] = Field(
-        default=None, description="e.g. '500 Meters' (WITHIN_A_DISTANCE only)."
+    """Input contract for materializing a spatial relationship selection."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class or layer from which features "
+            "will be selected. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
     )
-    invert: bool = Field(default=False, description="True = NOT relationship.")
-    overwrite: bool = False
+    select_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class or layer used as the spatial "
+            "selector. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path containing the selected features. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    relationship: SpatialRelationship = Field(
+        default="INTERSECT",
+        description=(
+            "Spatial relationship used for the selection, such as INTERSECT, "
+            "WITHIN, CONTAINS, or WITHIN_A_DISTANCE."
+        ),
+    )
+    search_distance: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional search distance such as '500 Meters'. Primarily used with "
+            "WITHIN_A_DISTANCE; leave None for relationships that do not require "
+            "a distance."
+        ),
+    )
+    invert: bool = Field(
+        default=False,
+        description=(
+            "When true, select features that do not satisfy the requested spatial "
+            "relationship."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "select_features": "read",
@@ -98,12 +216,52 @@ class SelectByLocationInput(ToolInput):
 
 
 class SpatialJoinInput(ToolInput):
-    target_features: str
-    join_features: str
-    out_features: str
-    join_operation: Literal["JOIN_ONE_TO_ONE", "JOIN_ONE_TO_MANY"] = "JOIN_ONE_TO_ONE"
-    match_option: SpatialRelationship = "INTERSECT"
-    overwrite: bool = False
+    """Input contract for joining attributes by spatial relationship."""
+
+    target_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the target feature class or layer that will receive "
+            "joined attributes. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    join_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class or layer whose attributes will be "
+            "joined to the target features. The path must be inside a configured "
+            "PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create with the spatial join "
+            "result. Existing outputs require overwrite=true."
+        ),
+    )
+    join_operation: Literal["JOIN_ONE_TO_ONE", "JOIN_ONE_TO_MANY"] = Field(
+        default="JOIN_ONE_TO_ONE",
+        description=(
+            "Join cardinality. JOIN_ONE_TO_ONE aggregates matching join features "
+            "onto each target feature; JOIN_ONE_TO_MANY creates one output row per "
+            "target/join match."
+        ),
+    )
+    match_option: SpatialRelationship = Field(
+        default="INTERSECT",
+        description=(
+            "Spatial match rule used to relate target and join features, such as "
+            "INTERSECT, WITHIN, CONTAINS, or WITHIN_A_DISTANCE."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "target_features": "read",
         "join_features": "read",
@@ -112,13 +270,36 @@ class SpatialJoinInput(ToolInput):
 
 
 class NearAnalysisInput(ToolInput):
-    in_features: str = Field(..., description="MODIFIED in place: NEAR_* fields added.")
-    near_features: str
+    """Input contract for ArcPy Near, which mutates the input dataset."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class that will be modified in "
+            "place. ArcPy Near adds or updates NEAR_FID and NEAR_DIST fields, so "
+            "use a copied working dataset when possible."
+        ),
+    )
+    near_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class used to find nearest features. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
     search_radius: Optional[str] = Field(
-        default=None, description="e.g. '1 Kilometers'"
+        default=None,
+        description=(
+            "Optional maximum search radius, for example '1 Kilometers'. Use None "
+            "to let ArcPy search for the nearest feature without a radius limit."
+        ),
     )
     confirm: bool = Field(
-        default=False, description="Must be true: mutates the input dataset."
+        default=False,
+        description=(
+            "Must be true. near_analysis mutates the input dataset by adding or "
+            "updating NEAR_* fields."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
@@ -127,12 +308,49 @@ class NearAnalysisInput(ToolInput):
 
 
 class GenerateNearTableInput(ToolInput):
-    in_features: str
-    near_features: str
-    out_table: str
-    closest_count: int = Field(default=1, ge=1, le=100)
-    search_radius: Optional[str] = None
-    overwrite: bool = False
+    """Input contract for writing nearest-neighbor relationships to a table."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class whose nearby features will "
+            "be measured. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    near_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class searched for near candidates. The "
+            "path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output table path to create with near-feature relationships "
+            "and distances. Existing outputs require overwrite=true."
+        ),
+    )
+    closest_count: int = Field(
+        default=1,
+        ge=1,
+        le=100,
+        description=(
+            "Maximum number of nearest candidates to write per input feature. "
+            "Use 1 for nearest-only workflows."
+        ),
+    )
+    search_radius: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional maximum search radius, for example '500 Meters'. Use None "
+            "to allow ArcPy to search without a radius limit."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output table is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "near_features": "read",
@@ -141,48 +359,136 @@ class GenerateNearTableInput(ToolInput):
 
 
 class MinimumBoundingGeometryInput(InOutInput):
+    """Input contract for creating bounding geometry around features."""
+
     geometry_type: Literal[
         "RECTANGLE_BY_AREA",
         "RECTANGLE_BY_WIDTH",
         "CONVEX_HULL",
         "CIRCLE",
         "ENVELOPE",
-    ] = "CONVEX_HULL"
-    group_option: Literal["NONE", "ALL"] = "NONE"
+    ] = Field(
+        default="CONVEX_HULL",
+        description=(
+            "Bounding geometry type to create, such as CONVEX_HULL, ENVELOPE, "
+            "CIRCLE, RECTANGLE_BY_AREA, or RECTANGLE_BY_WIDTH."
+        ),
+    )
+    group_option: Literal["NONE", "ALL"] = Field(
+        default="NONE",
+        description=(
+            "Grouping behavior for bounding geometry creation. NONE creates "
+            "bounding geometry per feature; ALL creates one geometry for all inputs."
+        ),
+    )
 
 
 class FeatureToPointInput(InOutInput):
-    point_location: Literal["CENTROID", "INSIDE"] = "CENTROID"
+    """Input contract for converting features to representative points."""
+
+    point_location: Literal["CENTROID", "INSIDE"] = Field(
+        default="CENTROID",
+        description=(
+            "Point placement method. CENTROID uses the geometric centroid; INSIDE "
+            "places the point inside the input feature when possible."
+        ),
+    )
 
 
 class FeatureVerticesToPointsInput(InOutInput):
-    point_location: Literal["ALL", "MID", "START", "END", "BOTH_ENDS"] = "ALL"
+    """Input contract for extracting vertices from features as points."""
+
+    point_location: Literal["ALL", "MID", "START", "END", "BOTH_ENDS"] = Field(
+        default="ALL",
+        description=(
+            "Which vertices to extract as points: ALL vertices, MID points, START "
+            "vertices, END vertices, or BOTH_ENDS for line endpoints."
+        ),
+    )
 
 
 class MultipartToSinglepartInput(InOutInput):
-    pass
+    """Input contract for splitting multipart features into singlepart features."""
 
 
 class SimplifyFeaturesInput(InOutInput):
-    algorithm: Literal["POINT_REMOVE", "BEND_SIMPLIFY", "WEIGHTED_AREA"] = (
-        "POINT_REMOVE"
+    """Input contract for simplifying polygon or polyline geometry."""
+
+    algorithm: Literal["POINT_REMOVE", "BEND_SIMPLIFY", "WEIGHTED_AREA"] = Field(
+        default="POINT_REMOVE",
+        description=(
+            "Simplification algorithm passed to ArcPy. POINT_REMOVE is general "
+            "purpose, BEND_SIMPLIFY preserves major bends, and WEIGHTED_AREA is "
+            "commonly used for polygon simplification."
+        ),
     )
-    tolerance: str = Field(..., description="e.g. '10 Meters'")
+    tolerance: str = Field(
+        ...,
+        description=(
+            "Simplification tolerance with units, for example '10 Meters'. Larger "
+            "values remove more detail."
+        ),
+    )
 
 
 class SmoothFeaturesInput(InOutInput):
-    algorithm: Literal["PAEK", "BEZIER_INTERPOLATION"] = "PAEK"
+    """Input contract for smoothing polygon or polyline geometry."""
+
+    algorithm: Literal["PAEK", "BEZIER_INTERPOLATION"] = Field(
+        default="PAEK",
+        description=(
+            "Smoothing algorithm passed to ArcPy. PAEK uses a tolerance distance; "
+            "BEZIER_INTERPOLATION creates smoother curves without a tolerance in "
+            "some ArcPy workflows."
+        ),
+    )
     tolerance: str = Field(
-        ..., description="PAEK smoothing tolerance, e.g. '100 Meters'"
+        ...,
+        description=(
+            "PAEK smoothing tolerance with units, for example '100 Meters'. "
+            "Required by the current worker implementation."
+        ),
     )
 
 
 class SummarizeWithinInput(ToolInput):
-    in_polygons: str
-    in_sum_features: str
-    out_features: str
-    keep_all_polygons: bool = True
-    overwrite: bool = False
+    """Input contract for summarizing features inside polygon areas."""
+
+    in_polygons: str = Field(
+        ...,
+        description=(
+            "Absolute path to polygon features that define summary areas, such as "
+            "districts, parcels, buffers, or grid cells. The path must be inside "
+            "a configured PathGuard allowed root."
+        ),
+    )
+    in_sum_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to point, line, or polygon features to summarize within "
+            "each polygon. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create with summary attributes. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    keep_all_polygons: bool = Field(
+        default=True,
+        description=(
+            "When true, keep all input polygons even if no summary features fall "
+            "inside them. When false, keep only polygons with intersecting summaries."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_polygons": "read",
         "in_sum_features": "read",
@@ -191,10 +497,35 @@ class SummarizeWithinInput(ToolInput):
 
 
 class FrequencyAnalysisInput(ToolInput):
-    in_table: str
-    out_table: str
-    frequency_fields: List[str] = Field(..., min_length=1, max_length=20)
-    overwrite: bool = False
+    """Input contract for counting unique attribute value combinations."""
+
+    in_table: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input table or feature class whose attribute "
+            "frequencies will be counted. The path must be inside a configured "
+            "PathGuard allowed root."
+        ),
+    )
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output table path to create with frequency counts. Existing "
+            "outputs require overwrite=true."
+        ),
+    )
+    frequency_fields: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=20,
+        description=(
+            "Field names used to define unique combinations for frequency counts."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output table is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_table": "read",
         "out_table": "write",
@@ -218,13 +549,43 @@ StatType = Literal[
 
 
 class StatisticsAnalysisInput(ToolInput):
-    in_table: str
-    out_table: str
-    statistics_fields: List[Tuple[str, StatType]] = Field(
-        ..., min_length=1, description="[[field, SUM|MEAN|...], ...]"
+    """Input contract for writing summary statistics to a table."""
+
+    in_table: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input table or feature class whose fields will "
+            "be summarized. The path must be inside a configured PathGuard allowed root."
+        ),
     )
-    case_field: Optional[str] = None
-    overwrite: bool = False
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output table path to create with summary statistics. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    statistics_fields: List[Tuple[str, StatType]] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "List of [field_name, statistic_type] pairs, such as "
+            "[['POP', 'SUM'], ['AREA', 'MEAN']]. Statistic type may be SUM, "
+            "MEAN, MIN, MAX, STD, COUNT, FIRST, LAST, RANGE, MEDIAN, VARIANCE, "
+            "or UNIQUE."
+        ),
+    )
+    case_field: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional field used to group statistics. Use None to calculate one "
+            "summary row for all input records."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output table is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_table": "read",
         "out_table": "write",
@@ -232,11 +593,41 @@ class StatisticsAnalysisInput(ToolInput):
 
 
 class TabulateIntersectionInput(ToolInput):
-    in_zone_features: str
-    zone_fields: List[str] = Field(..., min_length=1)
-    in_class_features: str
-    out_table: str
-    overwrite: bool = False
+    """Input contract for cross-tabulating class features inside zones."""
+
+    in_zone_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to polygon zone features, such as districts, parcels, "
+            "or planning units. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    zone_fields: List[str] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "One or more zone identifier fields used to group intersection results."
+        ),
+    )
+    in_class_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to class features whose overlap with each zone will be "
+            "tabulated. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output table path to create with tabulated intersection "
+            "results. Existing outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output table is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_zone_features": "read",
         "in_class_features": "read",
@@ -245,25 +636,79 @@ class TabulateIntersectionInput(ToolInput):
 
 
 class IdentityFeaturesInput(TwoLayerOverlay):
-    pass
+    """Input contract for identity overlay analysis."""
 
 
 class SymmetricalDifferenceInput(TwoLayerOverlay):
-    pass
+    """Input contract for extracting non-overlapping parts of two feature layers."""
 
 
 class CreateFishnetInput(ToolInput):
-    out_features: str
-    origin_x: float
-    origin_y: float
-    y_axis_y: Optional[float] = Field(
-        default=None, description="Y of the orientation point; default origin_y+10."
+    """Input contract for creating a rectangular fishnet/grid feature class."""
+
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path for the fishnet grid. The path "
+            "must be inside a configured PathGuard allowed root; existing outputs "
+            "require overwrite=true."
+        ),
     )
-    cell_width: float = Field(..., gt=0)
-    cell_height: float = Field(..., gt=0)
-    rows: int = Field(..., ge=1, le=10000)
-    columns: int = Field(..., ge=1, le=10000)
-    geometry_type: Literal["POLYLINE", "POLYGON"] = "POLYGON"
-    create_label_points: bool = False
-    overwrite: bool = False
+    origin_x: float = Field(
+        ...,
+        description="X coordinate of the fishnet origin point.",
+    )
+    origin_y: float = Field(
+        ...,
+        description="Y coordinate of the fishnet origin point.",
+    )
+    y_axis_y: Optional[float] = Field(
+        default=None,
+        description=(
+            "Y coordinate of the orientation point used to define the fishnet "
+            "Y-axis direction. Defaults to origin_y + 10 when omitted."
+        ),
+    )
+    cell_width: float = Field(
+        ...,
+        gt=0,
+        description="Width of each fishnet cell in the output coordinate units.",
+    )
+    cell_height: float = Field(
+        ...,
+        gt=0,
+        description="Height of each fishnet cell in the output coordinate units.",
+    )
+    rows: int = Field(
+        ...,
+        ge=1,
+        le=10000,
+        description="Number of fishnet rows to create.",
+    )
+    columns: int = Field(
+        ...,
+        ge=1,
+        le=10000,
+        description="Number of fishnet columns to create.",
+    )
+    geometry_type: Literal["POLYLINE", "POLYGON"] = Field(
+        default="POLYGON",
+        description=(
+            "Output grid geometry type. POLYGON creates cells as polygons; "
+            "POLYLINE creates grid lines."
+        ),
+    )
+    create_label_points: bool = Field(
+        default=False,
+        description=(
+            "When true, ask ArcPy to create label points for fishnet cells where "
+            "supported by the geoprocessing tool."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output fishnet is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"out_features": "write"}

--- a/arcgis_mcp/contracts/raster_ops.py
+++ b/arcgis_mcp/contracts/raster_ops.py
@@ -46,11 +46,29 @@ _MAP_ALGEBRA_CHARS = re.compile(r"^[A-Za-z0-9_+\-*/().,%<>=!&|~^ \t]+$")
 
 
 class RasterInOut(ToolInput):
-    """Shared base: one input raster, one output raster."""
+    """Shared base for tools that read one raster and create one raster output."""
 
-    in_raster: str = Field(..., min_length=1)
-    out_raster: str = Field(..., min_length=1)
-    overwrite: bool = False
+    in_raster: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path to the existing input raster dataset. The path must "
+            "be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_raster: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute output raster path to create. The path must be inside a "
+            "configured PathGuard allowed root; existing outputs require "
+            "overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output raster is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_raster": "read",
         "out_raster": "write",
@@ -58,18 +76,30 @@ class RasterInOut(ToolInput):
 
 
 class DemDerivative(RasterInOut):
-    """Shared base: DEM-derived surfaces with a vertical exaggeration factor."""
+    """Shared base for DEM-derived raster surfaces."""
 
     z_factor: float = Field(
         default=1.0,
         gt=0,
-        description="Vertical unit conversion (e.g. 0.3048 if Z is in feet "
-        "and XY in meters).",
+        description=(
+            "Vertical unit conversion or exaggeration factor. Use 1.0 when XY "
+            "and Z units already match; for example use 0.3048 when elevation "
+            "Z values are in feet and XY units are meters."
+        ),
     )
 
 
 class ExtractByMaskInput(RasterInOut):
-    mask: str = Field(..., description="Polygon FC or raster acting as the mask.")
+    """Input contract for extracting raster cells inside a mask."""
+
+    mask: str = Field(
+        ...,
+        description=(
+            "Absolute path to a polygon feature class or raster dataset used as "
+            "the extraction mask. The mask must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_raster": "read",
         "mask": "read",
@@ -86,11 +116,48 @@ class RasterCalculatorInput(ToolInput):
     parser receives the expression verbatim.
     """
 
-    rasters: List[str] = Field(..., min_length=1, max_length=10)
-    variable_names: List[str] = Field(..., min_length=1, max_length=10)
-    expression: str = Field(..., min_length=1, max_length=2000)
-    out_raster: str
-    overwrite: bool = False
+    rasters: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description=(
+            "Absolute paths to input raster datasets used by the map-algebra "
+            "expression. Each path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    variable_names: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description=(
+            "Identifier names used inside the expression to reference the rasters. "
+            "The list length must match rasters, and each name must be a valid "
+            "identifier such as red, nir, or elevation."
+        ),
+    )
+    expression: str = Field(
+        ...,
+        min_length=1,
+        max_length=2000,
+        description=(
+            "Map-algebra expression using only declared variable_names, numbers, "
+            "operators, comparisons, parentheses, commas, and supported Spatial "
+            "Analyst functions. Inline file paths, quotes, and dunder access are "
+            "rejected."
+        ),
+    )
+    out_raster: str = Field(
+        ...,
+        description=(
+            "Absolute output raster path to create from the map-algebra result. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output raster is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "rasters": "read_list",
         "out_raster": "write",
@@ -135,23 +202,83 @@ class RasterCalculatorInput(ToolInput):
 
 
 class ResampleRasterInput(RasterInOut):
-    cell_size: float = Field(..., gt=0, description="Target cell size (map units).")
-    resampling_type: RasterResampling = "NEAREST"
+    """Input contract for changing raster cell size and resampling method."""
+
+    cell_size: float = Field(
+        ...,
+        gt=0,
+        description=(
+            "Target output cell size in map units. Larger values produce coarser "
+            "rasters; smaller values produce finer rasters."
+        ),
+    )
+    resampling_type: RasterResampling = Field(
+        default="NEAREST",
+        description=(
+            "Resampling method used when creating the output raster. Use NEAREST "
+            "for categorical rasters and bilinear/cubic-style methods for "
+            "continuous rasters when available."
+        ),
+    )
 
 
 class MosaicToNewRasterInput(ToolInput):
-    rasters: List[str] = Field(..., min_length=2, max_length=50)
-    output_location: str = Field(..., description="Existing folder or GDB.")
+    """Input contract for mosaicking multiple rasters into a new raster dataset."""
+
+    rasters: List[str] = Field(
+        ...,
+        min_length=2,
+        max_length=50,
+        description=(
+            "Absolute paths to two or more input raster datasets to mosaic. Each "
+            "path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    output_location: str = Field(
+        ...,
+        description=(
+            "Absolute path to an existing folder or geodatabase where the mosaic "
+            "output raster will be created. Must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
     raster_name: str = Field(
         ...,
         min_length=1,
         max_length=128,
-        description="Output name (with .tif etc. if folder).",
+        description=(
+            "Name of the output raster. Include an extension such as .tif when "
+            "writing to a folder; use a geodatabase raster name when writing to a GDB."
+        ),
     )
-    number_of_bands: int = Field(..., ge=1, le=400)
-    pixel_type: PixelType = "32_BIT_FLOAT"
-    mosaic_method: MosaicMethod = "LAST"
-    cell_size: Optional[float] = Field(default=None, gt=0)
+    number_of_bands: int = Field(
+        ...,
+        ge=1,
+        le=400,
+        description="Number of bands in the output raster dataset.",
+    )
+    pixel_type: PixelType = Field(
+        default="32_BIT_FLOAT",
+        description=(
+            "Pixel depth and numeric type for the output raster, such as "
+            "8_BIT_UNSIGNED, 16_BIT_SIGNED, or 32_BIT_FLOAT."
+        ),
+    )
+    mosaic_method: MosaicMethod = Field(
+        default="LAST",
+        description=(
+            "Method used to resolve overlapping raster cells, such as FIRST, LAST, "
+            "BLEND, MEAN, MINIMUM, or MAXIMUM."
+        ),
+    )
+    cell_size: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional output cell size in map units. Use None to let ArcPy choose "
+            "from the input rasters."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "rasters": "read_list",
         "output_location": "read",
@@ -159,11 +286,44 @@ class MosaicToNewRasterInput(ToolInput):
 
 
 class RasterToPolygonInput(ToolInput):
-    in_raster: str
-    out_features: str
-    simplify: bool = Field(default=True, description="Smooth cell-edge stairsteps.")
-    raster_field: str = Field(default="Value", max_length=64)
-    overwrite: bool = False
+    """Input contract for converting raster zones or classes to polygons."""
+
+    in_raster: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input raster dataset to convert to polygons. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output polygon feature class path to create. Existing "
+            "outputs require overwrite=true."
+        ),
+    )
+    simplify: bool = Field(
+        default=True,
+        description=(
+            "When true, smooth polygon boundaries to reduce cell-edge stair steps. "
+            "When false, preserve exact raster cell edges."
+        ),
+    )
+    raster_field: str = Field(
+        default="Value",
+        max_length=64,
+        description=(
+            "Raster attribute field used to assign polygon values. The default "
+            "Value field is appropriate for most classified rasters."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output polygon feature "
+            "class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_raster": "read",
         "out_features": "write",
@@ -171,14 +331,50 @@ class RasterToPolygonInput(ToolInput):
 
 
 class PolygonToRasterInput(ToolInput):
-    in_features: str
-    value_field: str = Field(..., min_length=1, max_length=64)
-    out_raster: str
-    cell_assignment: Literal["CELL_CENTER", "MAXIMUM_AREA", "MAXIMUM_COMBINED_AREA"] = (
-        "CELL_CENTER"
+    """Input contract for converting polygon features to raster cells."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input polygon feature class. The path must be "
+            "inside a configured PathGuard allowed root."
+        ),
     )
-    cell_size: float = Field(..., gt=0)
-    overwrite: bool = False
+    value_field: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Attribute field whose values will be burned into output raster cells."
+        ),
+    )
+    out_raster: str = Field(
+        ...,
+        description=(
+            "Absolute output raster path to create. Existing outputs require "
+            "overwrite=true."
+        ),
+    )
+    cell_assignment: Literal["CELL_CENTER", "MAXIMUM_AREA", "MAXIMUM_COMBINED_AREA"] = (
+        Field(
+            default="CELL_CENTER",
+            description=(
+                "Rule used to assign polygon values to raster cells. CELL_CENTER "
+                "uses the polygon covering the cell center; MAXIMUM_AREA uses the "
+                "polygon occupying the largest cell area; MAXIMUM_COMBINED_AREA "
+                "combines areas by value."
+            ),
+        )
+    )
+    cell_size: float = Field(
+        ...,
+        gt=0,
+        description="Output raster cell size in map units.",
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output raster is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_raster": "write",
@@ -186,12 +382,49 @@ class PolygonToRasterInput(ToolInput):
 
 
 class ZonalStatisticsInput(ToolInput):
-    in_zone_data: str = Field(..., description="Polygon FC or zone raster.")
-    zone_field: str = Field(..., min_length=1, max_length=64)
-    in_value_raster: str
-    out_raster: str
-    statistics_type: ZonalStatType = "MEAN"
-    overwrite: bool = False
+    """Input contract for calculating one zonal statistic as a raster output."""
+
+    in_zone_data: str = Field(
+        ...,
+        description=(
+            "Absolute path to polygon zone features or a zone raster. The path "
+            "must be inside a configured PathGuard allowed root."
+        ),
+    )
+    zone_field: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Zone identifier field used to group value raster cells for statistics."
+        ),
+    )
+    in_value_raster: str = Field(
+        ...,
+        description=(
+            "Absolute path to the raster containing values to summarize within "
+            "each zone. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_raster: str = Field(
+        ...,
+        description=(
+            "Absolute output raster path to create with one statistic value per "
+            "zone. Existing outputs require overwrite=true."
+        ),
+    )
+    statistics_type: ZonalStatType = Field(
+        default="MEAN",
+        description=(
+            "Statistic to calculate for each zone, such as MEAN, SUM, MIN, MAX, "
+            "RANGE, STD, MEDIAN, MAJORITY, MINORITY, or VARIETY. ALL is rejected "
+            "for raster output."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output raster is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_zone_data": "read",
         "in_value_raster": "read",
@@ -209,12 +442,48 @@ class ZonalStatisticsInput(ToolInput):
 
 
 class ZonalStatisticsAsTableInput(ToolInput):
-    in_zone_data: str
-    zone_field: str = Field(..., min_length=1, max_length=64)
-    in_value_raster: str
-    out_table: str
-    statistics_type: ZonalStatType = "ALL"
-    overwrite: bool = False
+    """Input contract for writing zonal statistics to a standalone table."""
+
+    in_zone_data: str = Field(
+        ...,
+        description=(
+            "Absolute path to polygon zone features or a zone raster. The path "
+            "must be inside a configured PathGuard allowed root."
+        ),
+    )
+    zone_field: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Zone identifier field used to group value raster cells for statistics."
+        ),
+    )
+    in_value_raster: str = Field(
+        ...,
+        description=(
+            "Absolute path to the raster containing values to summarize within "
+            "each zone. The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_table: str = Field(
+        ...,
+        description=(
+            "Absolute output table path to create with zonal statistics. Existing "
+            "outputs require overwrite=true."
+        ),
+    )
+    statistics_type: ZonalStatType = Field(
+        default="ALL",
+        description=(
+            "Statistic or statistic set to calculate. ALL writes the full supported "
+            "statistics set to the output table."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output table is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_zone_data": "read",
         "in_value_raster": "read",
@@ -223,26 +492,91 @@ class ZonalStatisticsAsTableInput(ToolInput):
 
 
 class SlopeAnalysisInput(DemDerivative):
-    output_measurement: Literal["DEGREE", "PERCENT_RISE"] = "DEGREE"
+    """Input contract for deriving slope from an elevation raster."""
+
+    output_measurement: Literal["DEGREE", "PERCENT_RISE"] = Field(
+        default="DEGREE",
+        description=(
+            "Slope output unit. DEGREE returns slope angle in degrees; "
+            "PERCENT_RISE returns rise over run as a percentage."
+        ),
+    )
 
 
 class AspectAnalysisInput(DemDerivative):
-    pass
+    """Input contract for deriving aspect direction from an elevation raster."""
 
 
 class HillshadeInput(DemDerivative):
-    azimuth: float = Field(default=315.0, ge=0.0, le=360.0)
-    altitude: float = Field(default=45.0, ge=0.0, le=90.0)
-    model_shadows: bool = False
+    """Input contract for deriving shaded relief from an elevation raster."""
+
+    azimuth: float = Field(
+        default=315.0,
+        ge=0.0,
+        le=360.0,
+        description=(
+            "Illumination azimuth in degrees clockwise from north. The default "
+            "315 degrees represents northwest light."
+        ),
+    )
+    altitude: float = Field(
+        default=45.0,
+        ge=0.0,
+        le=90.0,
+        description=(
+            "Illumination altitude angle in degrees above the horizon. Higher "
+            "values create more overhead lighting."
+        ),
+    )
+    model_shadows: bool = Field(
+        default=False,
+        description=(
+            "When true, model terrain shadows where supported by ArcPy hillshade."
+        ),
+    )
 
 
 class ContourLinesInput(ToolInput):
-    in_dem: str
-    out_features: str = Field(..., description="Output polyline FC of isolines.")
-    contour_interval: float = Field(..., gt=0)
-    base_contour: float = 0.0
-    z_factor: float = Field(default=1.0, gt=0)
-    overwrite: bool = False
+    """Input contract for deriving contour isolines from a DEM raster."""
+
+    in_dem: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input elevation raster. The path must be inside "
+            "a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output polyline feature class path for contour isolines. "
+            "Existing outputs require overwrite=true."
+        ),
+    )
+    contour_interval: float = Field(
+        ...,
+        gt=0,
+        description="Elevation interval between contour lines in DEM vertical units.",
+    )
+    base_contour: float = Field(
+        default=0.0,
+        description="Base contour value from which intervals are calculated.",
+    )
+    z_factor: float = Field(
+        default=1.0,
+        gt=0,
+        description=(
+            "Vertical unit conversion or exaggeration factor applied before "
+            "contour generation."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing output contour feature "
+            "class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_dem": "read",
         "out_features": "write",
@@ -250,34 +584,84 @@ class ContourLinesInput(ToolInput):
 
 
 class FlowDirectionInput(RasterInOut):
+    """Input contract for deriving hydrologic flow direction from a surface raster."""
+
     force_flow: bool = Field(
         default=False,
-        description="True forces edge cells to flow outward (FORCE).",
+        description=(
+            "When true, force edge cells to flow outward using ArcPy FORCE "
+            "behavior. When false, use the default NORMAL behavior."
+        ),
     )
 
 
 class FillSinksInput(RasterInOut):
+    """Input contract for filling sinks in an elevation raster."""
+
     z_limit: Optional[float] = Field(
         default=None,
         gt=0,
-        description="Max sink depth to fill; None fills all sinks.",
+        description=(
+            "Maximum sink depth to fill. Use None to fill all sinks detected by "
+            "ArcPy; use a positive value to limit filling to shallow sinks."
+        ),
     )
 
 
 class ClipRasterInput(RasterInOut):
-    """Clip by explicit rectangle and/or template dataset geometry."""
+    """Input contract for clipping a raster by rectangle or template dataset."""
 
-    xmin: Optional[float] = None
-    ymin: Optional[float] = None
-    xmax: Optional[float] = None
-    ymax: Optional[float] = None
+    xmin: Optional[float] = Field(
+        default=None,
+        description=(
+            "Minimum X coordinate of the clipping rectangle. Provide all four "
+            "rectangle bounds together, or leave all bounds None and use "
+            "template_dataset."
+        ),
+    )
+    ymin: Optional[float] = Field(
+        default=None,
+        description=(
+            "Minimum Y coordinate of the clipping rectangle. Provide all four "
+            "rectangle bounds together, or leave all bounds None and use "
+            "template_dataset."
+        ),
+    )
+    xmax: Optional[float] = Field(
+        default=None,
+        description=(
+            "Maximum X coordinate of the clipping rectangle. Must be greater than "
+            "xmin when rectangle clipping is used."
+        ),
+    )
+    ymax: Optional[float] = Field(
+        default=None,
+        description=(
+            "Maximum Y coordinate of the clipping rectangle. Must be greater than "
+            "ymin when rectangle clipping is used."
+        ),
+    )
     template_dataset: Optional[str] = Field(
-        default=None, description="FC/raster whose extent (or geometry) clips."
+        default=None,
+        description=(
+            "Optional feature class or raster whose extent, or polygon geometry "
+            "when use_clipping_geometry=true, defines the clipping area."
+        ),
     )
     use_clipping_geometry: bool = Field(
-        default=False, description="Clip to template polygon geometry, not extent."
+        default=False,
+        description=(
+            "When true, clip to the template polygon geometry instead of only the "
+            "template extent. Requires template_dataset."
+        ),
     )
-    nodata_value: Optional[str] = None
+    nodata_value: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional NoData value assigned outside the clipping area where ArcPy "
+            "supports it."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_raster": "read",
         "template_dataset": "read",

--- a/arcgis_mcp/tools/data_mgmt.py
+++ b/arcgis_mcp/tools/data_mgmt.py
@@ -210,157 +210,277 @@ _CAT = Category.DATA_MGMT
 _SPECS: tuple[tuple[str, str, type, Any, bool], ...] = (
     (
         "create_feature_class",
-        "Create a new feature class in a GDB (CreateFeatureclass).",
+        (
+            "Create an empty feature class inside an existing file geodatabase "
+            "using ArcPy CreateFeatureclass. Use this to prepare a controlled "
+            "output dataset with a chosen geometry type and optional WKID before "
+            "loading, editing, or analysis. Reads the target geodatabase path "
+            "inside a PathGuard allowed root and returns the created dataset."
+        ),
         c.CreateFeatureClassInput,
         _create_feature_class,
         False,
     ),
     (
         "delete_dataset",
-        "Delete a FC/table/raster (Delete). Irreversible; requires confirm=true.",
+        (
+            "Delete an existing feature class, table, raster, or geodatabase item "
+            "using ArcPy Delete. This operation is irreversible and mutates local "
+            "project data, so confirm=true is required. The target dataset must "
+            "be inside a configured PathGuard allowed root."
+        ),
         c.DeleteDatasetInput,
         _delete_dataset,
         True,
     ),
     (
         "copy_features",
-        "Copy features preserving CRS and schema (CopyFeatures).",
+        (
+            "Copy an existing feature class or layer to a new output feature "
+            "class using ArcPy CopyFeatures. Use this to create a safe working "
+            "copy while preserving geometry, attributes, schema, and spatial "
+            "reference. Reads in_features and writes out_features inside "
+            "PathGuard allowed roots; existing outputs require overwrite=true."
+        ),
         c.CopyFeaturesInput,
         _copy_features,
         False,
     ),
     (
         "rename_dataset",
-        "Rename a dataset inside its GDB (Rename).",
+        (
+            "Rename an existing dataset within its current workspace using ArcPy "
+            "Rename. Use this for controlled cleanup of intermediate feature "
+            "classes, tables, or rasters. This mutates the workspace namespace "
+            "but does not edit feature geometry or attribute values; the dataset "
+            "path must be inside a PathGuard allowed root."
+        ),
         c.RenameDatasetInput,
         _rename_dataset,
         False,
     ),
     (
         "add_field",
-        "Add one field to a table/FC (AddField).",
+        (
+            "Add one attribute field to an existing feature class or table using "
+            "ArcPy AddField. Use this to prepare schema before imports, joins, "
+            "calculations, or manual editing. Mutates the input dataset schema; "
+            "the dataset must be inside a PathGuard allowed root."
+        ),
         c.AddFieldInput,
         _add_field,
         False,
     ),
     (
         "delete_field",
-        "Drop fields from a table/FC (DeleteField). Requires confirm=true.",
+        (
+            "Delete one or more fields from an existing feature class or table "
+            "using ArcPy DeleteField. Use this only when unwanted attribute "
+            "columns should be permanently removed. This mutates the input schema "
+            "and drops data, so confirm=true is required."
+        ),
         c.DeleteFieldInput,
         _delete_field,
         True,
     ),
     (
         "calculate_field",
-        "Compute field values with an ARCADE (default, sandboxed) / SQL / "
-        "PYTHON3 expression (CalculateField). Overwrites column values: "
-        "requires confirm=true; PYTHON3 additionally executes code and is "
-        "refused without explicit confirmation.",
+        (
+            "Calculate values for an existing field using ArcPy CalculateField. "
+            "Use this for controlled attribute updates with ARCADE, SQL, or "
+            "PYTHON3 expressions. The default ARCADE mode is preferred for "
+            "LLM-facing workflows; PYTHON3 executes worker-side code and, like "
+            "all value overwrites, requires confirm=true."
+        ),
         c.CalculateFieldInput,
         _calculate_field,
         True,
     ),
     (
         "add_fields_batch",
-        "Add multiple fields in one call (AddFields).",
+        (
+            "Add multiple fields to an existing feature class or table in one "
+            "operation using ArcPy AddFields. Use this to prepare a complete "
+            "attribute schema before imports, calculations, joins, or QA/QC. "
+            "Mutates the input dataset schema; field names, types, aliases, and "
+            "lengths are validated before execution."
+        ),
         c.AddFieldsBatchInput,
         _add_fields_batch,
         False,
     ),
     (
         "get_field_info",
-        "List field names, types, lengths and aliases (ListFields).",
+        (
+            "List field metadata for an existing feature class or table using "
+            "ArcPy ListFields. Use this to inspect schema before calculating, "
+            "deleting, joining, or exporting attributes. Returns field names, "
+            "types, lengths, aliases, and nullable status without modifying data."
+        ),
         c.GetFieldInfoInput,
         _get_field_info,
         False,
     ),
     (
         "get_feature_count",
-        "Return the feature/row count (GetCount).",
+        (
+            "Return the row or feature count for an existing dataset using ArcPy "
+            "GetCount. Use this as a lightweight validation step before and after "
+            "geoprocessing, filtering, import, export, or QA/QC workflows. Reads "
+            "one dataset inside a PathGuard allowed root and does not modify data."
+        ),
         c.GetFeatureCountInput,
         _get_feature_count,
         False,
     ),
     (
         "describe_dataset",
-        "Return CRS, geometry type and extent metadata (Describe).",
+        (
+            "Describe an existing feature class, table, raster, or geodatabase "
+            "item using ArcPy Describe. Use this to inspect data type, geometry "
+            "type, coordinate reference system, and extent before choosing an "
+            "analysis tool. Reads metadata only and does not modify the dataset."
+        ),
         c.DescribeDatasetInput,
         _describe_dataset,
         False,
     ),
     (
         "create_file_gdb",
-        "Create a new file geodatabase (CreateFileGDB).",
+        (
+            "Create a new file geodatabase using ArcPy CreateFileGDB. Use this "
+            "to prepare a workspace for scratch outputs, copied data, imports, "
+            "or project-specific analysis results. The parent folder must exist "
+            "inside a PathGuard allowed root; the tool returns the created "
+            "geodatabase path."
+        ),
         c.CreateFileGdbInput,
         _create_file_gdb,
         False,
     ),
     (
         "compact_gdb",
-        "Compact a GDB to reclaim space (Compact).",
+        (
+            "Compact an existing file geodatabase using ArcPy Compact. Use this "
+            "as maintenance after heavy editing, deletion, or intermediate output "
+            "cleanup to reclaim storage and improve geodatabase performance. "
+            "Mutates the geodatabase storage layout but not feature content."
+        ),
         c.CompactGdbInput,
         _compact_gdb,
         False,
     ),
     (
         "export_to_shapefile",
-        "Export a FC to shapefile in a folder (FeatureClassToShapefile).",
+        (
+            "Export a feature class to shapefile format using ArcPy "
+            "FeatureClassToShapefile. Use this when data must be shared with "
+            "legacy GIS tools or systems that require shapefiles. Reads the input "
+            "features and writes shapefile components into an existing output "
+            "folder inside PathGuard allowed roots."
+        ),
         c.ExportToShapefileInput,
         _export_to_shapefile,
         False,
     ),
     (
         "export_to_geojson",
-        "Export features to GeoJSON in WGS84 (FeaturesToJSON).",
+        (
+            "Export features to a WGS84 GeoJSON file using ArcPy FeaturesToJSON. "
+            "Use this to share vector data with web maps, APIs, notebooks, or "
+            "non-Esri tools. Reads in_features and writes an output .geojson file "
+            "inside PathGuard allowed roots; existing files require overwrite=true."
+        ),
         c.ExportToGeojsonInput,
         _export_to_geojson,
         False,
     ),
     (
         "import_from_geojson",
-        "Create a FC from GeoJSON (JSONToFeatures).",
+        (
+            "Convert a GeoJSON file into an ArcGIS feature class using ArcPy "
+            "JSONToFeatures. Use this to bring web, API, or exchange-format vector "
+            "data into a geodatabase for ArcGIS analysis. Reads an input .geojson "
+            "file and writes out_features inside PathGuard allowed roots; existing "
+            "outputs require overwrite=true."
+        ),
         c.ImportFromGeojsonInput,
         _import_from_geojson,
         False,
     ),
     (
         "table_to_excel",
-        "Export an attribute table to .xlsx (TableToExcel).",
+        (
+            "Export an attribute table or feature class table to an Excel workbook "
+            "using ArcPy TableToExcel. Use this to share tabular GIS attributes "
+            "with analysts, reports, or spreadsheet workflows. Reads the input "
+            "table and writes an .xlsx file inside PathGuard allowed roots; "
+            "existing files require overwrite=true."
+        ),
         c.TableToExcelInput,
         _table_to_excel,
         False,
     ),
     (
         "excel_to_table",
-        "Import an .xlsx sheet as a GDB table (ExcelToTable).",
+        (
+            "Import an Excel worksheet into a geodatabase table using ArcPy "
+            "ExcelToTable. Use this to bring spreadsheet-based attributes, lookup "
+            "tables, or external tabular data into ArcGIS. Reads an .xlsx workbook "
+            "and writes a geodatabase table inside PathGuard allowed roots; existing "
+            "outputs require overwrite=true."
+        ),
         c.ExcelToTableInput,
         _excel_to_table,
         False,
     ),
     (
         "feature_to_csv",
-        "Export attributes to CSV (ExportTable, Pro 3.x).",
+        (
+            "Export a feature class or table to a CSV file using ArcPy ExportTable. "
+            "Use this to move attribute data into notebooks, data pipelines, reports, "
+            "or non-GIS tools. Reads the input table or feature class and writes a "
+            ".csv output inside PathGuard allowed roots; existing files require "
+            "overwrite=true."
+        ),
         c.FeatureToCsvInput,
         _feature_to_csv,
         False,
     ),
     (
         "get_extent",
-        "Return xmin/ymin/xmax/ymax of a dataset (Describe().extent).",
+        (
+            "Return xmin, ymin, xmax, ymax, and CRS metadata for an existing dataset "
+            "using ArcPy Describe().extent. Use this to understand spatial coverage "
+            "before clipping, map export, fishnet creation, raster analysis, or "
+            "spatial QA/QC. Reads metadata only and does not modify the dataset."
+        ),
         c.GetExtentInput,
         _get_extent,
         False,
     ),
     (
         "calculate_geometry",
-        "Write area/length/centroid values into a field (CalculateGeometryAttributes).",
+        (
+            "Calculate area, length, perimeter, centroid, or point coordinate values "
+            "into an attribute field using ArcPy CalculateGeometryAttributes. Use "
+            "this to populate measurement fields for reporting, QA/QC, labeling, "
+            "or downstream analysis. Mutates the input dataset by writing geometry "
+            "values into the specified field."
+        ),
         c.CalculateGeometryInput,
         _calculate_geometry,
         False,
     ),
     (
         "add_xy_coordinates",
-        "Add POINT_X/POINT_Y fields to a point FC (AddXY).",
+        (
+            "Add or update POINT_X and POINT_Y coordinate fields on point features "
+            "using ArcPy AddXY. Use this when point coordinates are needed for "
+            "export, QA/QC, labeling, tabular analysis, or integration with non-GIS "
+            "systems. Mutates the input dataset by adding or updating coordinate "
+            "fields, so run it on an intended working dataset."
+        ),
         c.AddXyCoordinatesInput,
         _add_xy_coordinates,
         False,

--- a/arcgis_mcp/tools/editing_topology.py
+++ b/arcgis_mcp/tools/editing_topology.py
@@ -100,51 +100,92 @@ _CAT = Category.EDITING
 _SPECS = (
     (
         "append_features",
-        "Append rows from FCs into an existing target (Append). Mutates the "
-        "target; requires confirm=true.",
+        (
+            "Append rows from one or more feature classes or tables into an existing "
+            "target dataset using ArcPy Append. Use this to load reviewed data, "
+            "merge field-compatible updates, or add processed batches into a live "
+            "target. This mutates the target dataset by inserting rows, so "
+            "confirm=true is required."
+        ),
         c.AppendFeaturesInput,
         _append_features,
         True,
     ),
     (
         "repair_geometry",
-        "Fix invalid geometries in place (RepairGeometry). Requires confirm=true.",
+        (
+            "Repair invalid feature geometry in place using ArcPy RepairGeometry. "
+            "Use this after check_geometry reports geometry problems or before "
+            "overlay, topology, network, or export operations that require valid "
+            "shapes. This rewrites geometry and may delete null geometries, so "
+            "confirm=true is required."
+        ),
         c.RepairGeometryInput,
         _repair_geometry,
         True,
     ),
     (
         "check_geometry",
-        "Report geometry problems into a table without fixing (CheckGeometry).",
+        (
+            "Check a feature class for geometry problems using ArcPy CheckGeometry "
+            "and write the findings to an output table. Use this as a non-mutating "
+            "QA/QC step before repair_geometry, overlay, topology validation, "
+            "conversion, or export. Reads the input features and writes a report "
+            "table inside PathGuard allowed roots."
+        ),
         c.CheckGeometryInput,
         _check_geometry,
         False,
     ),
     (
         "detect_feature_changes",
-        "Diff two line FCs spatially/attributively (DetectFeatureChanges).",
+        (
+            "Detect spatial or attribute changes between updated features and a "
+            "reference feature dataset using ArcPy DetectFeatureChanges. Use this "
+            "for QA/QC, version comparison, update review, or identifying changed "
+            "features within a search tolerance. Reads update_features and "
+            "base_features and writes a new out_features change dataset without "
+            "mutating the originals."
+        ),
         c.DetectFeatureChangesInput,
         _detect_feature_changes,
         False,
     ),
     (
         "delete_identical",
-        "Delete duplicate rows by field/geometry equality (DeleteIdentical). "
-        "Irreversible; requires confirm=true.",
+        (
+            "Delete duplicate rows from a feature class or table using ArcPy "
+            "DeleteIdentical based on selected fields and optional geometry "
+            "tolerance. Use this only on an intended working dataset to remove "
+            "duplicate records. This operation is irreversible and mutates the "
+            "input dataset, so confirm=true is required."
+        ),
         c.DeleteIdenticalInput,
         _delete_identical,
         True,
     ),
     (
         "eliminate_polygon_part",
-        "Merge small polygon parts into neighbors (EliminatePolygonPart).",
+        (
+            "Remove small polygon holes or parts using ArcPy EliminatePolygonPart "
+            "and write a cleaned output feature class. Use this for cartographic "
+            "cleanup, removing sliver holes, or simplifying polygon interiors by "
+            "area or percentage thresholds. Reads in_features and writes "
+            "out_features without modifying the source dataset."
+        ),
         c.EliminatePolygonPartInput,
         _eliminate_polygon_part,
         False,
     ),
     (
         "topology_check",
-        "Validate a geodatabase topology's rules (ValidateTopology).",
+        (
+            "Validate a geodatabase topology using ArcPy ValidateTopology. Use this "
+            "to refresh topology rule validation after editing, appending, repair, "
+            "or geometry cleanup workflows. Reads the topology dataset and returns "
+            "validation metadata; inspect the topology error feature classes in "
+            "ArcGIS Pro for rule violations."
+        ),
         c.TopologyCheckInput,
         _topology_check,
         False,

--- a/arcgis_mcp/tools/export_layout.py
+++ b/arcgis_mcp/tools/export_layout.py
@@ -190,55 +190,105 @@ _CAT = Category.EXPORT_LAYOUT
 _SPECS = (
     (
         "list_layouts",
-        "List layouts with page size and units (aprx.listLayouts).",
+        (
+            "List all layouts in a saved ArcGIS Pro .aprx project using "
+            "arcpy.mp listLayouts. Use this to discover layout names, page sizes, "
+            "and page units before exporting or modifying a layout. Reads the "
+            "project only and does not save or mutate the .aprx file."
+        ),
         c.ListLayoutsInput,
         _list_layouts,
     ),
     (
         "export_layout_pdf",
-        "Export a layout to PDF at a chosen DPI (layout.exportToPDF).",
+        (
+            "Export a selected ArcGIS Pro layout to a PDF file using "
+            "layout.exportToPDF. Use this for print-ready map sheets, reports, "
+            "submittals, or archival exports with controlled DPI and image quality. "
+            "Reads the .aprx project and writes out_pdf inside PathGuard allowed "
+            "roots; existing files require overwrite=true."
+        ),
         c.ExportLayoutPdfInput,
         _export_layout_pdf,
     ),
     (
         "export_layout_png",
-        "Export a layout to PNG at a chosen DPI (layout.exportToPNG).",
+        (
+            "Export a selected ArcGIS Pro layout to a PNG image using "
+            "layout.exportToPNG. Use this for previews, portfolio images, web "
+            "graphics, or presentation-ready map layouts with controlled DPI and "
+            "optional transparency. Reads the .aprx project and writes out_png "
+            "inside PathGuard allowed roots."
+        ),
         c.ExportLayoutPngInput,
         _export_layout_png,
     ),
     (
         "export_map_as_image",
-        "Export a map view directly to PNG without a layout (map.defaultView).",
+        (
+            "Export a map view directly to a PNG image using the map defaultView, "
+            "without requiring a layout. Use this for quick map snapshots, previews, "
+            "or automated image generation when a formal layout is unnecessary. "
+            "Reads the .aprx project and writes out_png with the requested width, "
+            "height, and resolution."
+        ),
         c.ExportMapAsImageInput,
         _export_map_as_image,
     ),
     (
         "set_map_scale",
-        "Set a layout map frame's camera scale (mf.camera.scale).",
+        (
+            "Set the camera scale denominator for a selected layout map frame "
+            "using arcpy.mp camera.scale. Use this before exporting a layout when "
+            "the map must be fixed to a known scale such as 1:1000 or 1:50,000. "
+            "This updates the .aprx project when save=true."
+        ),
         c.SetMapScaleInput,
         _set_map_scale,
     ),
     (
         "set_map_extent_from_layer",
-        "Fit a map frame's extent to a layer (mf.camera.setExtent).",
+        (
+            "Set a layout map frame extent to match a named layer using "
+            "mf.getLayerExtent and mf.camera.setExtent. Use this before exporting "
+            "a layout so the final map focuses on a dataset, study area, boundary, "
+            "or analysis result. This changes the map frame camera and saves the "
+            ".aprx project when save=true."
+        ),
         c.SetMapExtentFromLayerInput,
         _set_map_extent_from_layer,
     ),
     (
         "update_text_element",
-        "Rewrite a layout text element (elm.text).",
+        (
+            "Update the text content of a named layout text element using arcpy.mp "
+            "layout elements. Use this to automate titles, dates, subtitles, map "
+            "numbers, project names, notes, or report labels before export. This "
+            "modifies the selected layout and saves the .aprx project when save=true."
+        ),
         c.UpdateTextElementInput,
         _update_text_element,
     ),
     (
         "update_legend",
-        "Add or remove a layer in a layout legend (legend.addItem/removeItem).",
+        (
+            "Add or remove a layer entry in a selected layout legend using arcpy.mp "
+            "legend addItem or removeItem. Use this to synchronize legends with "
+            "automated layer changes before exporting maps. This modifies the "
+            "layout legend and saves the .aprx project when save=true."
+        ),
         c.UpdateLegendInput,
         _update_legend,
     ),
     (
         "set_layout_size",
-        "Change layout page dimensions (layout.pageWidth/pageHeight).",
+        (
+            "Change the physical page width and height of a selected ArcGIS Pro "
+            "layout using layout.pageWidth and layout.pageHeight. Use this to "
+            "switch between sheet sizes, portfolio formats, report pages, or "
+            "print/export templates. This modifies the layout and saves the .aprx "
+            "project when save=true."
+        ),
         c.SetLayoutSizeInput,
         _set_layout_size,
     ),

--- a/arcgis_mcp/tools/geometry.py
+++ b/arcgis_mcp/tools/geometry.py
@@ -246,166 +246,296 @@ _CAT = Category.GEOMETRY
 _SPECS = (
     (
         "intersect_features",
-        "Geometric intersection of 2+ layers (Intersect).",
+        (
+            "Overlay two or more feature layers using ArcPy Intersect and write "
+            "only the shared geometry to a new output feature class. Use this "
+            "to find areas, lines, or points common to multiple datasets while "
+            "preserving selected attributes. Reads all input feature paths and "
+            "writes out_features inside PathGuard allowed roots."
+        ),
         c.IntersectFeaturesInput,
         _intersect,
         False,
     ),
     (
         "union_features",
-        "Geometric union of 2+ polygon layers (Union).",
+        (
+            "Overlay two or more polygon feature layers using ArcPy Union and "
+            "write a new polygon feature class containing all combined areas. "
+            "Use this to compare zoning, land-use, administrative, or planning "
+            "layers while retaining attributes from each input. Reads input "
+            "features and writes out_features inside PathGuard allowed roots."
+        ),
         c.UnionFeaturesInput,
         _union,
         False,
     ),
     (
         "erase_features",
-        "Remove areas overlapping the overlay layer — cookie-cutter (Erase).",
+        (
+            "Remove portions of input features that overlap an erase layer using "
+            "ArcPy Erase. Use this for exclusion zones, masking restricted areas, "
+            "or subtracting one geography from another. Reads the input and "
+            "overlay feature paths and writes a new output feature class without "
+            "modifying the source datasets."
+        ),
         c.EraseFeaturesInput,
         _erase,
         False,
     ),
     (
         "dissolve_features",
-        "Merge geometries sharing attribute values (Dissolve).",
+        (
+            "Merge adjacent or overlapping features that share attribute values "
+            "using ArcPy Dissolve. Use this to generalize boundaries, aggregate "
+            "parcels, zones, roads, or other features by one or more dissolve "
+            "fields. Reads in_features and writes a new dissolved output feature "
+            "class inside PathGuard allowed roots."
+        ),
         c.DissolveFeaturesInput,
         _dissolve,
         False,
     ),
     (
         "merge_features",
-        "Combine same-schema layers into one FC (Merge).",
+        (
+            "Combine multiple compatible feature classes or layers into one output "
+            "feature class using ArcPy Merge. Use this to assemble same-schema "
+            "datasets from multiple sources, tiles, districts, or processing "
+            "batches. Reads all input feature paths and writes one new output "
+            "inside PathGuard allowed roots."
+        ),
         c.MergeFeaturesInput,
         _merge,
         False,
     ),
     (
         "select_by_attribute",
-        "Materialize a SQL attribute selection into a new FC (Select).",
+        (
+            "Materialize a SQL attribute query into a new feature class using "
+            "ArcPy Select. Use this when a stateless MCP workflow needs a saved "
+            "subset rather than an in-memory layer selection. Reads in_features, "
+            "applies where_clause, and writes the selected rows to out_features."
+        ),
         c.SelectByAttributeInput,
         _select_by_attribute,
         False,
     ),
     (
         "select_by_location",
-        "Materialize a spatial-relationship selection into a new FC "
-        "(SelectLayerByLocation pipeline).",
+        (
+            "Materialize a spatial relationship selection into a new feature class "
+            "using a MakeFeatureLayer, SelectLayerByLocation, and CopyFeatures "
+            "pipeline. Use this to persist features that intersect, contain, are "
+            "within, or are near another dataset. Writes the selected result to "
+            "out_features and removes the temporary layer."
+        ),
         c.SelectByLocationInput,
         _select_by_location,
         False,
     ),
     (
         "spatial_join",
-        "Join attributes by spatial relationship (SpatialJoin).",
+        (
+            "Join attributes from one feature layer to another based on spatial "
+            "relationships using ArcPy SpatialJoin. Use this to count, summarize, "
+            "or transfer nearby, contained, intersecting, or matching feature "
+            "attributes into a new output feature class. Reads target_features "
+            "and join_features and writes out_features inside PathGuard roots."
+        ),
         c.SpatialJoinInput,
         _spatial_join,
         False,
     ),
     (
         "near_analysis",
-        "Nearest-neighbor distance per feature; MUTATES input (Near). "
-        "Requires confirm=true.",
+        (
+            "Calculate nearest-neighbor distance from each input feature to nearby "
+            "features using ArcPy Near. This mutates the input dataset by adding "
+            "or updating NEAR_FID and NEAR_DIST fields, so confirm=true is "
+            "required. Use a copied working dataset when exposing this workflow "
+            "to an LLM or automated agent."
+        ),
         c.NearAnalysisInput,
         _near,
         True,
     ),
     (
         "generate_near_table",
-        "N nearest neighbors as a standalone table (GenerateNearTable).",
+        (
+            "Create a standalone proximity table between input features and near "
+            "features using ArcPy GenerateNearTable. Use this to record nearest "
+            "neighbors, distances, and candidate matches without modifying the "
+            "source datasets. Reads input and near feature paths and writes a new "
+            "out_table inside PathGuard allowed roots."
+        ),
         c.GenerateNearTableInput,
         _generate_near_table,
         False,
     ),
     (
         "minimum_bounding_geometry",
-        "Convex hull / envelope / circle per feature or group "
-        "(MinimumBoundingGeometry).",
+        (
+            "Create bounding geometries around input features using ArcPy "
+            "MinimumBoundingGeometry. Use this to generate convex hulls, envelopes, "
+            "circles, or other summary shapes for features or groups. Reads "
+            "in_features and writes a new output feature class with the requested "
+            "geometry_type and grouping behavior."
+        ),
         c.MinimumBoundingGeometryInput,
         _minimum_bounding_geometry,
         False,
     ),
     (
         "feature_to_point",
-        "Polygon/line centroids as points (FeatureToPoint).",
+        (
+            "Create representative point features from polygons or lines using "
+            "ArcPy FeatureToPoint. Use this to produce centroids or guaranteed "
+            "inside points for labeling, joins, sampling, or simplified analysis. "
+            "Reads in_features and writes a new point feature class to out_features."
+        ),
         c.FeatureToPointInput,
         _feature_to_point,
         False,
     ),
     (
         "feature_vertices_to_points",
-        "Extract vertices as points (FeatureVerticesToPoints).",
+        (
+            "Convert feature vertices to point features using ArcPy "
+            "FeatureVerticesToPoints. Use this to extract endpoints, all vertices, "
+            "midpoints, or dangle points from line or polygon geometry for QA/QC, "
+            "network checks, and geometry inspection. Reads in_features and "
+            "creates out_features inside PathGuard allowed roots."
+        ),
         c.FeatureVerticesToPointsInput,
         _feature_vertices_to_points,
         False,
     ),
     (
         "multipart_to_singlepart",
-        "Explode multipart geometries (MultipartToSinglepart).",
+        (
+            "Split multipart features into singlepart features using ArcPy "
+            "MultipartToSinglepart. Use this before per-feature editing, counting, "
+            "topology checks, joins, or analysis that requires one geometry part "
+            "per row. Reads in_features and creates out_features without modifying "
+            "the source dataset."
+        ),
         c.MultipartToSinglepartInput,
         _multipart_to_singlepart,
         False,
     ),
     (
         "simplify_features",
-        "Simplify polygon/line geometry; auto-detects shape type "
-        "(SimplifyPolygon/SimplifyLine).",
+        (
+            "Simplify polygon or polyline geometry using ArcPy SimplifyPolygon or "
+            "SimplifyLine after detecting the input shape type. Use this to reduce "
+            "vertex density for cartography, web export, performance, or scale-"
+            "appropriate analysis. Writes a simplified output feature class and "
+            "does not mutate the source features."
+        ),
         c.SimplifyFeaturesInput,
         _simplify,
         False,
     ),
     (
         "smooth_features",
-        "Smooth polygon/line corners; auto-detects shape type "
-        "(SmoothPolygon/SmoothLine).",
+        (
+            "Smooth polygon or polyline geometry using ArcPy SmoothPolygon or "
+            "SmoothLine after detecting the input shape type. Use this for "
+            "cartographic cleanup where angular boundaries or lines need a more "
+            "generalized appearance. Writes a new smoothed output feature class "
+            "without modifying the source dataset."
+        ),
         c.SmoothFeaturesInput,
         _smooth,
         False,
     ),
     (
         "summarize_within",
-        "Statistics of features falling inside polygons (SummarizeWithin).",
+        (
+            "Summarize features that fall within polygon areas using ArcPy "
+            "SummarizeWithin. Use this to count or aggregate points, lines, or "
+            "polygons by administrative zones, grid cells, parcels, buffers, or "
+            "service areas. Reads boundary polygons and summary features, then "
+            "writes a new summarized output feature class."
+        ),
         c.SummarizeWithinInput,
         _summarize_within,
         False,
     ),
     (
         "frequency_analysis",
-        "Count unique attribute value combinations (Frequency).",
+        (
+            "Count unique combinations of attribute values using ArcPy Frequency. "
+            "Use this to profile categorical fields, detect duplicates, summarize "
+            "classes, or prepare simple frequency tables for QA/QC and reporting. "
+            "Reads an input table and writes a new output table inside PathGuard "
+            "allowed roots."
+        ),
         c.FrequencyAnalysisInput,
         _frequency,
         False,
     ),
     (
         "statistics_analysis",
-        "SUM/MEAN/MIN/MAX/STD summary table (Statistics).",
+        (
+            "Calculate summary statistics for numeric or categorical fields using "
+            "ArcPy Statistics. Use this to aggregate counts, sums, means, minima, "
+            "maxima, standard deviations, or grouped statistics before reporting "
+            "or joining results back to features. Reads an input table and writes "
+            "a new output table."
+        ),
         c.StatisticsAnalysisInput,
         _statistics,
         False,
     ),
     (
         "tabulate_intersection",
-        "Cross-tabulate intersection areas of two layers (TabulateIntersection).",
+        (
+            "Cross-tabulate intersections between zone features and class features "
+            "using ArcPy TabulateIntersection. Use this to quantify how much of "
+            "each class falls inside each zone, such as land-use area by district "
+            "or habitat type by planning unit. Writes a standalone output table."
+        ),
         c.TabulateIntersectionInput,
         _tabulate_intersection,
         False,
     ),
     (
         "identity_features",
-        "Overlay keeping source geometry (Identity).",
+        (
+            "Overlay input features with identity features using ArcPy Identity. "
+            "Use this to transfer polygon or line attributes onto another feature "
+            "layer while preserving the input geometry where applicable. Reads "
+            "both input datasets and writes a new output feature class inside "
+            "PathGuard allowed roots."
+        ),
         c.IdentityFeaturesInput,
         _identity,
         False,
     ),
     (
         "symmetrical_difference",
-        "Non-overlapping parts of two layers (SymDiff).",
+        (
+            "Create the non-overlapping parts of two feature layers using ArcPy "
+            "SymmetricalDifference. Use this to compare boundaries, detect areas "
+            "present in only one of two datasets, or isolate disagreement between "
+            "two polygon/line sources. Writes a new output feature class and does "
+            "not modify the inputs."
+        ),
         c.SymmetricalDifferenceInput,
         _sym_diff,
         False,
     ),
     (
         "create_fishnet",
-        "Regular grid of cells (CreateFishnet).",
+        (
+            "Create a regular rectangular grid or fishnet feature class using "
+            "ArcPy CreateFishnet. Use this to build sampling grids, analysis "
+            "cells, index maps, planning units, or raster-like vector zones from "
+            "an origin, cell size, row/column count, and geometry type. Writes a "
+            "new grid dataset inside a PathGuard allowed root."
+        ),
         c.CreateFishnetInput,
         _create_fishnet,
         False,

--- a/arcgis_mcp/tools/raster_ops.py
+++ b/arcgis_mcp/tools/raster_ops.py
@@ -214,100 +214,172 @@ _CAT = Category.RASTER
 _SPECS = (
     (
         "extract_by_mask",
-        "Clip a raster by a polygon/raster mask (sa.ExtractByMask). "
-        "Requires Spatial Analyst.",
+        (
+            "Extract raster cells inside a polygon or raster mask using ArcPy "
+            "Spatial Analyst ExtractByMask. Use this to clip elevation, imagery, "
+            "land-cover, suitability, or other raster data to a study area before "
+            "analysis. Requires a Spatial Analyst license; reads in_raster and "
+            "mask inside PathGuard roots and writes out_raster."
+        ),
         c.ExtractByMaskInput,
         _extract_by_mask,
     ),
     (
         "raster_calculator",
-        "Map algebra over named raster variables, e.g. NDVI = (nir-red)/(nir+red) "
-        "(sa.RasterCalculator). Requires Spatial Analyst.",
+        (
+            "Run Spatial Analyst map algebra over explicitly named raster "
+            "variables using ArcPy RasterCalculator. Use this for NDVI, suitability "
+            "models, binary masks, raster normalization, and cell-by-cell formulas. "
+            "Requires a Spatial Analyst license; expressions may reference only "
+            "declared variable_names and validated map-algebra syntax."
+        ),
         c.RasterCalculatorInput,
         _raster_calculator,
     ),
     (
         "resample_raster",
-        "Change raster cell size with NEAREST/BILINEAR/CUBIC/MAJORITY (Resample).",
+        (
+            "Change raster cell size using ArcPy Resample. Use this to align "
+            "resolution before overlay, modeling, visualization, or export. Reads "
+            "one input raster and writes out_raster inside PathGuard roots; choose "
+            "a resampling method appropriate for categorical or continuous data."
+        ),
         c.ResampleRasterInput,
         _resample_raster,
     ),
     (
         "mosaic_to_new_raster",
-        "Merge multiple rasters into one dataset (MosaicToNewRaster).",
+        (
+            "Merge multiple raster datasets into one new raster using ArcPy "
+            "MosaicToNewRaster. Use this to combine tiles, scenes, DEM sheets, or "
+            "image bands into a single dataset. Reads two or more input rasters "
+            "and writes a named raster into an existing folder or geodatabase."
+        ),
         c.MosaicToNewRasterInput,
         _mosaic_to_new_raster,
     ),
     (
         "raster_to_polygon",
-        "Vectorize a classified raster (conversion.RasterToPolygon).",
+        (
+            "Convert raster zones or classes to polygon features using ArcPy "
+            "RasterToPolygon. Use this to vectorize classified rasters, suitability "
+            "classes, land-cover codes, or cell regions for GIS editing, overlay, "
+            "and cartographic workflows. Reads in_raster and writes out_features."
+        ),
         c.RasterToPolygonInput,
         _raster_to_polygon,
     ),
     (
         "polygon_to_raster",
-        "Rasterize polygons by a value field (conversion.PolygonToRaster).",
+        (
+            "Convert polygon features to a raster dataset using ArcPy "
+            "PolygonToRaster. Use this when vector zones, classes, parcels, or "
+            "planning units need to become raster cells for map algebra, "
+            "suitability modeling, or raster overlay. Reads polygon features and "
+            "writes out_raster using value_field, cell_assignment, and cell_size."
+        ),
         c.PolygonToRasterInput,
         _polygon_to_raster,
     ),
     (
         "zonal_statistics",
-        "Per-zone raster statistic as a raster (sa.ZonalStatistics). "
-        "Requires Spatial Analyst.",
+        (
+            "Calculate one raster statistic per zone and write the result as a "
+            "raster using ArcPy Spatial Analyst ZonalStatistics. Use this when "
+            "each zone should receive a MEAN, SUM, MIN, MAX, or similar value "
+            "from an input value raster. Requires a Spatial Analyst license."
+        ),
         c.ZonalStatisticsInput,
         _zonal_statistics,
     ),
     (
         "zonal_statistics_as_table",
-        "Per-zone raster statistics as a table (sa.ZonalStatisticsAsTable). "
-        "Requires Spatial Analyst.",
+        (
+            "Calculate zonal statistics and write the results to a standalone "
+            "table using ArcPy Spatial Analyst ZonalStatisticsAsTable. Use this "
+            "to summarize raster values by districts, parcels, watersheds, grid "
+            "cells, or other zone datasets. Requires a Spatial Analyst license."
+        ),
         c.ZonalStatisticsAsTableInput,
         _zonal_statistics_as_table,
     ),
     (
         "slope_analysis",
-        "Slope (degrees or percent rise) from a DEM (sa.Slope). "
-        "Requires Spatial Analyst.",
+        (
+            "Derive slope from an elevation raster using ArcPy Spatial Analyst "
+            "Slope. Use this in terrain, hydrology, accessibility, hazard, and "
+            "site suitability workflows. Requires a Spatial Analyst license; "
+            "writes a slope raster in degrees or percent rise using z_factor."
+        ),
         c.SlopeAnalysisInput,
         _slope,
     ),
     (
         "aspect_analysis",
-        "Aspect (downslope direction) from a DEM (sa.Aspect). "
-        "Requires Spatial Analyst.",
+        (
+            "Derive downslope aspect direction from an elevation raster using "
+            "ArcPy Spatial Analyst Aspect. Use this for terrain interpretation, "
+            "solar exposure, ecological modeling, hydrology, and site suitability. "
+            "Requires a Spatial Analyst license and writes a new aspect raster."
+        ),
         c.AspectAnalysisInput,
         _aspect,
     ),
     (
         "hillshade",
-        "Illumination shading from a DEM with sun azimuth/altitude "
-        "(sa.Hillshade). Requires Spatial Analyst.",
+        (
+            "Create shaded relief from an elevation raster using ArcPy Spatial "
+            "Analyst Hillshade. Use this for terrain visualization, map backdrops, "
+            "and DEM QA/QC with controlled sun azimuth, altitude, shadow modeling, "
+            "and z_factor. Requires a Spatial Analyst license."
+        ),
         c.HillshadeInput,
         _hillshade,
     ),
     (
         "contour_lines",
-        "Vector elevation isolines from a DEM (sa.Contour). Requires Spatial Analyst.",
+        (
+            "Create vector elevation isolines from a DEM raster using ArcPy "
+            "Spatial Analyst Contour. Use this to generate cartographic contours, "
+            "terrain analysis inputs, or elevation reference lines. Requires a "
+            "Spatial Analyst license and writes a polyline feature class."
+        ),
         c.ContourLinesInput,
         _contour_lines,
     ),
     (
         "flow_direction",
-        "D8 hydrological flow direction raster (sa.FlowDirection). "
-        "Requires Spatial Analyst.",
+        (
+            "Derive a hydrologic flow-direction raster from an elevation or "
+            "surface raster using ArcPy Spatial Analyst FlowDirection. Use this "
+            "before flow accumulation, watershed delineation, drainage modeling, "
+            "or stream extraction. Requires a Spatial Analyst license; writes "
+            "out_raster and can optionally force edge cells to flow outward."
+        ),
         c.FlowDirectionInput,
         _flow_direction,
     ),
     (
         "fill_sinks",
-        "Fill DEM sinks for hydrological conditioning (sa.Fill). "
-        "Requires Spatial Analyst.",
+        (
+            "Fill sinks or depressions in an elevation raster using ArcPy Spatial "
+            "Analyst Fill. Use this to hydrologically condition DEMs before flow "
+            "direction, flow accumulation, watershed, or stream network analysis. "
+            "Requires a Spatial Analyst license; optional z_limit controls maximum "
+            "sink depth to fill."
+        ),
         c.FillSinksInput,
         _fill_sinks,
     ),
     (
         "clip_raster",
-        "Clip a raster by rectangle and/or template geometry (management.Clip).",
+        (
+            "Clip a raster by rectangle, template extent, or template polygon "
+            "geometry using ArcPy management Clip. Use this to crop imagery, DEMs, "
+            "or classified rasters to a study area without requiring Spatial "
+            "Analyst. Reads in_raster and optional template_dataset and writes "
+            "out_raster inside PathGuard roots."
+        ),
         c.ClipRasterInput,
         _clip_raster,
     ),


### PR DESCRIPTION
Improves MCP tool and input schema definitions for Glama quality scoring.

This PR does not change ArcPy execution behavior. It improves:
- ToolSpec descriptions for low-scoring Glama tools
- Pydantic Field descriptions for input parameters
- path boundary, overwrite, confirm, and mutation guidance
- usage guidance for data management, geometry, raster, export/layout, and editing/topology tools

The goal is to improve Glama Tool Definition Quality from C toward B/A while preserving the existing runtime behavior.