### PR TITLE
docs: raise Glama tool definition quality

### DIFF
--- a/arcgis_mcp/contracts/geometry.py
+++ b/arcgis_mcp/contracts/geometry.py
@@ -1,4 +1,4 @@
-"""Input models — Category 3: Geometry & Analysis (catalog #33-55)."""
+﻿"""Input models â€” Category 3: Geometry & Analysis (catalog #33-55)."""
 
 from __future__ import annotations
 
@@ -644,71 +644,94 @@ class SymmetricalDifferenceInput(TwoLayerOverlay):
 
 
 class CreateFishnetInput(ToolInput):
-    """Input contract for creating a rectangular fishnet/grid feature class."""
+    """Input contract for creating a rectangular fishnet or analysis grid."""
 
     out_features: str = Field(
         ...,
         description=(
-            "Absolute output feature class path for the fishnet grid. The path "
-            "must be inside a configured PathGuard allowed root; existing outputs "
-            "require overwrite=true."
+            "Absolute output feature class path for the generated fishnet grid. "
+            "Use a geodatabase feature class path for project analysis outputs. "
+            "The path must be inside a configured PathGuard allowed root; existing "
+            "outputs require overwrite=true."
         ),
     )
     origin_x: float = Field(
         ...,
-        description="X coordinate of the fishnet origin point.",
+        description=(
+            "X coordinate of the fishnet origin point, usually the lower-left "
+            "corner of the grid in the output coordinate system."
+        ),
     )
     origin_y: float = Field(
         ...,
-        description="Y coordinate of the fishnet origin point.",
+        description=(
+            "Y coordinate of the fishnet origin point, usually the lower-left "
+            "corner of the grid in the output coordinate system."
+        ),
     )
     y_axis_y: Optional[float] = Field(
         default=None,
         description=(
-            "Y coordinate of the orientation point used to define the fishnet "
-            "Y-axis direction. Defaults to origin_y + 10 when omitted."
+            "Y coordinate of the orientation point used with origin_x to define "
+            "the fishnet Y-axis direction. Leave None to use origin_y + 10, which "
+            "creates a north-oriented grid in typical projected coordinate systems."
         ),
     )
     cell_width: float = Field(
         ...,
         gt=0,
-        description="Width of each fishnet cell in the output coordinate units.",
+        description=(
+            "Width of each fishnet cell in output coordinate system units. For "
+            "projected data this is usually meters or feet."
+        ),
     )
     cell_height: float = Field(
         ...,
         gt=0,
-        description="Height of each fishnet cell in the output coordinate units.",
+        description=(
+            "Height of each fishnet cell in output coordinate system units. Use "
+            "the same value as cell_width for square cells."
+        ),
     )
     rows: int = Field(
         ...,
         ge=1,
         le=10000,
-        description="Number of fishnet rows to create.",
+        description=(
+            "Number of fishnet rows to create. Combined with cell_height, this "
+            "controls the total grid height."
+        ),
     )
     columns: int = Field(
         ...,
         ge=1,
         le=10000,
-        description="Number of fishnet columns to create.",
+        description=(
+            "Number of fishnet columns to create. Combined with cell_width, this "
+            "controls the total grid width."
+        ),
     )
     geometry_type: Literal["POLYLINE", "POLYGON"] = Field(
         default="POLYGON",
         description=(
-            "Output grid geometry type. POLYGON creates cells as polygons; "
-            "POLYLINE creates grid lines."
+            "Output grid geometry type. Use POLYGON when cells should be analysis "
+            "zones, sampling units, planning units, or overlay features. Use "
+            "POLYLINE when only grid lines are needed for indexing or cartography."
         ),
     )
     create_label_points: bool = Field(
         default=False,
         description=(
-            "When true, ask ArcPy to create label points for fishnet cells where "
-            "supported by the geoprocessing tool."
+            "When true, ask ArcPy CreateFishnet to create label points for grid "
+            "cells where supported. Use this when cell centers are needed for "
+            "labels, sampling points, or downstream joins."
         ),
     )
     overwrite: bool = Field(
         default=False,
         description=(
-            "Set true only when replacing an existing output fishnet is intended."
+            "Set true only when replacing an existing fishnet output feature class "
+            "is intended."
         ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {"out_features": "write"}

--- a/arcgis_mcp/contracts/map_mgmt.py
+++ b/arcgis_mcp/contracts/map_mgmt.py
@@ -17,29 +17,63 @@ from .base import PathRole, ToolInput
 
 
 class AprxInput(ToolInput):
-    """Shared base: every map-management tool starts from an .aprx path."""
+    """Shared base for tools that read a saved ArcGIS Pro project file."""
 
-    aprx_path: str = Field(..., min_length=1, description="Absolute .aprx path.")
+    aprx_path: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path to the saved ArcGIS Pro .aprx project file. The path "
+            "must be inside a configured PathGuard allowed root. Tools operate on "
+            "the saved project file, not a live open ArcGIS Pro session."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"aprx_path": "read"}
 
 
 class MapScopedInput(AprxInput):
-    """Shared base: tools that target one map inside the project."""
+    """Shared base for tools that target one map inside an ArcGIS Pro project."""
 
     map_name: Optional[str] = Field(
-        default=None, description="Map name; None targets the first map."
+        default=None,
+        description=(
+            "Name of the map inside the .aprx project. Use None to target the "
+            "first map returned by ArcGIS Pro."
+        ),
     )
 
 
 class LayerScopedInput(MapScopedInput):
-    """Shared base: tools that target one layer inside one map."""
+    """Shared base for tools that target one layer inside one map."""
 
-    layer_name: str = Field(..., min_length=1, description="Layer (Contents) name.")
+    layer_name: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Layer name as shown in the ArcGIS Pro Contents pane for the selected "
+            "map. The layer must exist in the resolved map."
+        ),
+    )
 
 
 class AddLayerToMapInput(MapScopedInput):
-    data_path: str = Field(..., description="Dataset to add (FC/raster path).")
-    save: bool = Field(default=True, description="Persist the .aprx afterwards.")
+    """Input contract for adding a dataset as a layer to a project map."""
+
+    data_path: str = Field(
+        ...,
+        description=(
+            "Absolute path to the feature class, table, raster, or supported GIS "
+            "dataset to add as a map layer. The dataset must be inside a configured "
+            "PathGuard allowed root."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after adding the layer. Use false "
+            "for temporary in-memory inspection before another operation."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "aprx_path": "read",
         "data_path": "read",
@@ -47,43 +81,122 @@ class AddLayerToMapInput(MapScopedInput):
 
 
 class RemoveLayerFromMapInput(LayerScopedInput):
-    save: bool = True
+    """Input contract for removing a layer from a map in a saved project."""
+
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after removing the layer from the map."
+        ),
+    )
     confirm: bool = Field(
-        default=False, description="Must be true: removing a layer is destructive."
+        default=False,
+        description=(
+            "Must be true. Removing a layer mutates the saved map structure in the "
+            ".aprx project, although it does not delete the underlying dataset."
+        ),
     )
 
 
 class ListMapsInput(AprxInput):
-    pass
+    """List maps available in a saved ArcGIS Pro project without modifying it."""
 
 
 class ListLayersInMapInput(MapScopedInput):
-    pass
+    """List layers in a selected map without modifying the ArcGIS Pro project."""
 
 
 class SetLayerVisibilityInput(LayerScopedInput):
-    visible: bool = Field(..., description="True to show, False to hide.")
-    save: bool = True
+    """Input contract for showing or hiding a layer in a selected map."""
+
+    visible: bool = Field(
+        ...,
+        description=(
+            "True to show the layer in the map; false to hide it. This changes "
+            "layer visibility in the .aprx project when save=true."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after changing layer visibility."
+        ),
+    )
 
 
 class MoveLayerOrderInput(LayerScopedInput):
-    reference_layer: str = Field(..., min_length=1)
-    position: Literal["BEFORE", "AFTER"] = "BEFORE"
-    save: bool = True
+    """Input contract for moving a layer before or after another layer."""
+
+    reference_layer: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Name of the existing reference layer used as the placement anchor "
+            "for the moved layer."
+        ),
+    )
+    position: Literal["BEFORE", "AFTER"] = Field(
+        default="BEFORE",
+        description=(
+            "Where to place layer_name relative to reference_layer in the map "
+            "drawing order: BEFORE or AFTER."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after updating layer draw order."
+        ),
+    )
 
 
 class RenameLayerInput(LayerScopedInput):
-    new_name: str = Field(..., min_length=1, max_length=255)
-    save: bool = True
+    """Input contract for renaming a layer in a selected map."""
+
+    new_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description=(
+            "New layer name to display in the ArcGIS Pro Contents pane. This "
+            "renames the map layer only and does not rename the underlying dataset."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description="When true, save the .aprx project after renaming the layer.",
+    )
 
 
 class ZoomToLayerInput(LayerScopedInput):
-    save: bool = True
+    """Input contract for setting a map view or frame extent to a layer."""
+
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after updating the view or camera "
+            "extent to the selected layer."
+        ),
+    )
 
 
 class SetLayerSymbologyInput(LayerScopedInput):
-    lyrx_path: str = Field(..., description="Source .lyrx symbology file.")
-    save: bool = True
+    """Input contract for applying symbology from a .lyrx layer file."""
+
+    lyrx_path: str = Field(
+        ...,
+        description=(
+            "Absolute path to the source .lyrx layer file whose symbology will be "
+            "applied to the target layer. The file must be inside a configured "
+            "PathGuard allowed root."
+        ),
+    )
+    save: bool = Field(
+        default=True,
+        description=(
+            "When true, save the .aprx project after applying the layer symbology."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "aprx_path": "read",
         "lyrx_path": "read",
@@ -91,4 +204,4 @@ class SetLayerSymbologyInput(LayerScopedInput):
 
 
 class SaveProjectInput(AprxInput):
-    pass
+    """Input contract for explicitly saving a saved ArcGIS Pro project file."""

--- a/arcgis_mcp/contracts/network_analysis.py
+++ b/arcgis_mcp/contracts/network_analysis.py
@@ -10,25 +10,61 @@ from .base import PathRole, ToolInput
 
 
 class NetworkBaseInput(ToolInput):
-    """Shared base: every NA tool solves against a network dataset."""
+    """Shared base for network analysis tools solved against a network dataset."""
 
-    network_dataset: str = Field(..., description="Path to the network dataset.")
+    network_dataset: str = Field(
+        ...,
+        description=(
+            "Absolute path to the ArcGIS network dataset used for routing or "
+            "accessibility analysis. The path must be inside a configured "
+            "PathGuard allowed root and must be usable by ArcPy Network Analyst."
+        ),
+    )
     travel_mode: Optional[str] = Field(
         default=None,
-        description="Named travel mode (e.g. 'Driving Time'); None = default.",
+        description=(
+            "Optional named travel mode from the network dataset, for example "
+            "'Driving Time' or 'Walking Time'. Use None to let ArcPy use the "
+            "network dataset default travel mode."
+        ),
         max_length=120,
     )
-    out_features: str = Field(..., description="Solved result feature class.")
-    overwrite: bool = False
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create with the solved network "
+            "analysis result. Existing outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing network analysis output "
+            "feature class is intended."
+        ),
+    )
 
 
 class ServiceAreaInput(NetworkBaseInput):
-    facilities: str = Field(..., description="Point FC of facilities.")
+    """Input contract for solving service area polygons or lines around facilities."""
+
+    facilities: str = Field(
+        ...,
+        description=(
+            "Absolute path to point facilities used as service area origins, such "
+            "as schools, hospitals, stations, depots, or stores. The path must be "
+            "inside a configured PathGuard allowed root."
+        ),
+    )
     cutoffs: List[float] = Field(
         ...,
         min_length=1,
         max_length=10,
-        description="Break values in travel-mode units, e.g. [5, 10, 15] minutes.",
+        description=(
+            "Break values in the selected travel mode units, for example "
+            "[5, 10, 15] for minutes when using a time-based travel mode. Each "
+            "cutoff creates a service area threshold around the facilities."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "network_dataset": "read",
@@ -38,7 +74,16 @@ class ServiceAreaInput(NetworkBaseInput):
 
 
 class RouteAnalysisInput(NetworkBaseInput):
-    stops: str = Field(..., description="Ordered point FC of route stops (A->B->...).")
+    """Input contract for solving routes through ordered stop points."""
+
+    stops: str = Field(
+        ...,
+        description=(
+            "Absolute path to an ordered point feature class of route stops, such "
+            "as A-to-B or multi-stop stop sequences. The path must be inside a "
+            "configured PathGuard allowed root."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "network_dataset": "read",
         "stops": "read",
@@ -47,10 +92,32 @@ class RouteAnalysisInput(NetworkBaseInput):
 
 
 class OdCostMatrixInput(NetworkBaseInput):
-    origins: str
-    destinations: str
+    """Input contract for solving origin-destination travel cost relationships."""
+
+    origins: str = Field(
+        ...,
+        description=(
+            "Absolute path to point origin features, such as homes, demand points, "
+            "facilities, depots, or candidate locations. The path must be inside "
+            "a configured PathGuard allowed root."
+        ),
+    )
+    destinations: str = Field(
+        ...,
+        description=(
+            "Absolute path to point destination features, such as services, jobs, "
+            "facilities, stores, stations, or opportunities. The path must be "
+            "inside a configured PathGuard allowed root."
+        ),
+    )
     cutoff: Optional[float] = Field(
-        default=None, gt=0, description="Max impedance; None = unlimited."
+        default=None,
+        gt=0,
+        description=(
+            "Optional maximum impedance or travel cost in the selected travel mode "
+            "units. Use None to solve without an explicit cutoff; use a positive "
+            "value to limit origin-destination matches."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "network_dataset": "read",
@@ -61,9 +128,33 @@ class OdCostMatrixInput(NetworkBaseInput):
 
 
 class ClosestFacilityInput(NetworkBaseInput):
-    facilities: str
-    incidents: str
-    facilities_to_find: int = Field(default=1, ge=1, le=100)
+    """Input contract for finding nearest facilities for incident points."""
+
+    facilities: str = Field(
+        ...,
+        description=(
+            "Absolute path to candidate facility points that may be matched to "
+            "incidents, such as hospitals, stations, schools, depots, or stores. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    incidents: str = Field(
+        ...,
+        description=(
+            "Absolute path to incident or demand point features that need nearest "
+            "facility matches. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    facilities_to_find: int = Field(
+        default=1,
+        ge=1,
+        le=100,
+        description=(
+            "Number of nearest facilities to find for each incident. Use 1 for "
+            "nearest-only workflows, or a higher value for candidate comparison."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "network_dataset": "read",
         "facilities": "read",

--- a/arcgis_mcp/contracts/projection.py
+++ b/arcgis_mcp/contracts/projection.py
@@ -16,40 +16,85 @@ RasterResampling = Literal["NEAREST", "BILINEAR", "CUBIC", "MAJORITY"]
 
 
 class DefineProjectionInput(ToolInput):
-    """Assign a CRS to a dataset whose spatial reference is unknown.
+    """Assign CRS metadata to a dataset whose spatial reference is unknown.
 
     DefineProjection rewrites metadata only — it does NOT transform
     coordinates. Defining the wrong CRS silently corrupts every downstream
     analysis, hence the confirm gate.
     """
 
-    dataset: str = Field(..., min_length=1)
+    dataset: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path to the dataset whose coordinate reference metadata will "
+            "be assigned. The path must be inside a configured PathGuard allowed "
+            "root. This does not transform coordinates; it only defines metadata."
+        ),
+    )
     wkid: int = Field(
         ...,
         ge=_WKID_MIN,
         le=_WKID_MAX,
-        description="EPSG/WKID, e.g. 5258 (TUREF) or 32635.",
+        description=(
+            "EPSG or Esri WKID to assign as the dataset spatial reference, for "
+            "example 5258 for TUREF/TM or 32635 for WGS 84 / UTM zone 35N."
+        ),
     )
     confirm: bool = Field(
         default=False,
-        description="Must be true: redefining a CRS rewrites dataset metadata.",
+        description=(
+            "Must be true. define_projection rewrites CRS metadata in place and "
+            "can make downstream analysis incorrect if the WKID does not match the "
+            "dataset's actual coordinate system."
+        ),
     )
     path_fields: ClassVar[dict[str, PathRole]] = {"dataset": "read"}
 
 
 class ProjectFeaturesInput(ToolInput):
-    """Transform a vector dataset into a different CRS (Project)."""
+    """Transform a vector feature dataset into a different coordinate system."""
 
-    in_features: str
-    out_features: str
-    out_wkid: int = Field(..., ge=_WKID_MIN, le=_WKID_MAX)
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class or layer to reproject. The "
+            "path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        description=(
+            "Absolute output feature class path to create in the target coordinate "
+            "system. The path must be inside a configured PathGuard allowed root; "
+            "existing outputs require overwrite=true."
+        ),
+    )
+    out_wkid: int = Field(
+        ...,
+        ge=_WKID_MIN,
+        le=_WKID_MAX,
+        description=(
+            "Target EPSG or Esri WKID for the output feature class. Coordinates "
+            "are transformed into this spatial reference using ArcPy Project."
+        ),
+    )
     transform_method: Optional[str] = Field(
         default=None,
-        description="Named geographic transformation when datums differ, "
-        "e.g. 'ITRF_2014_To_ETRF_2014'. None lets arcpy choose.",
+        description=(
+            "Optional named geographic transformation used when source and target "
+            "datums differ, for example 'ITRF_2014_To_ETRF_2014'. Use None to let "
+            "ArcPy choose where possible."
+        ),
         max_length=120,
     )
-    overwrite: bool = False
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing projected output feature "
+            "class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_features": "write",
@@ -57,25 +102,68 @@ class ProjectFeaturesInput(ToolInput):
 
 
 class GetSpatialReferenceInput(ToolInput):
-    """Inspect a CRS definition by WKID. Pure lookup — touches no files."""
+    """Inspect a spatial reference definition by WKID without touching files."""
 
-    wkid: int = Field(..., ge=_WKID_MIN, le=_WKID_MAX)
+    wkid: int = Field(
+        ...,
+        ge=_WKID_MIN,
+        le=_WKID_MAX,
+        description=(
+            "EPSG or Esri WKID to inspect. This is a pure spatial-reference lookup "
+            "and has no filesystem input or output."
+        ),
+    )
     # No path_fields: this tool has no filesystem surface at all.
 
 
 class ProjectRasterInput(ToolInput):
-    """Reproject a raster dataset (ProjectRaster)."""
+    """Reproject a raster dataset into a different coordinate system."""
 
-    in_raster: str
-    out_raster: str
-    out_wkid: int = Field(..., ge=_WKID_MIN, le=_WKID_MAX)
+    in_raster: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input raster dataset to reproject. The path must "
+            "be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_raster: str = Field(
+        ...,
+        description=(
+            "Absolute output raster path to create in the target coordinate system. "
+            "The path must be inside a configured PathGuard allowed root; existing "
+            "outputs require overwrite=true."
+        ),
+    )
+    out_wkid: int = Field(
+        ...,
+        ge=_WKID_MIN,
+        le=_WKID_MAX,
+        description=(
+            "Target EPSG or Esri WKID for the output raster. Raster cells are "
+            "projected into this spatial reference using ArcPy ProjectRaster."
+        ),
+    )
     resampling_type: RasterResampling = Field(
         default="NEAREST",
-        description="NEAREST for categorical rasters; BILINEAR/CUBIC for "
-        "continuous surfaces (DEM, imagery).",
+        description=(
+            "Resampling method used while projecting raster cells. Use NEAREST for "
+            "categorical rasters such as land cover or zones; use BILINEAR or "
+            "CUBIC for continuous surfaces such as DEMs or imagery; use MAJORITY "
+            "for classified rasters where appropriate."
+        ),
     )
-    cell_size: Optional[float] = Field(default=None, gt=0)
-    overwrite: bool = False
+    cell_size: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional output cell size in target map units. Use None to let ArcPy "
+            "derive an appropriate cell size from the input raster and projection."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output raster is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_raster": "read",
         "out_raster": "write",

--- a/arcgis_mcp/contracts/spatial_stats.py
+++ b/arcgis_mcp/contracts/spatial_stats.py
@@ -21,11 +21,32 @@ DistanceMethod = Literal["EUCLIDEAN_DISTANCE", "MANHATTAN_DISTANCE"]
 
 
 class StatsInOut(ToolInput):
-    """Shared base: one input FC, one output FC."""
+    """Shared base for spatial statistics tools that read features and write features."""
 
-    in_features: str = Field(..., min_length=1)
-    out_features: str = Field(..., min_length=1)
-    overwrite: bool = False
+    in_features: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path to the input feature class used for spatial statistics. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_features: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute output feature class path to create with statistical results. "
+            "The path must be inside a configured PathGuard allowed root; existing "
+            "outputs require overwrite=true."
+        ),
+    )
+    overwrite: bool = Field(
+        default=False,
+        description=(
+            "Set true only when replacing an existing spatial statistics output "
+            "feature class is intended."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_features": "write",
@@ -33,30 +54,95 @@ class StatsInOut(ToolInput):
 
 
 class MeanCenterInput(StatsInOut):
-    weight_field: Optional[str] = Field(default=None, max_length=64)
-    case_field: Optional[str] = Field(default=None, max_length=64)
+    """Input contract for calculating the geographic mean center of features."""
+
+    weight_field: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Optional numeric field used to weight features when calculating the "
+            "mean center. Use None when every feature should contribute equally."
+        ),
+    )
+    case_field: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Optional field used to group features and calculate one mean center "
+            "per group. Use None to calculate one mean center for all features."
+        ),
+    )
 
 
 class DirectionalDistributionInput(StatsInOut):
+    """Input contract for creating standard deviational ellipse features."""
+
     ellipse_size: Literal[
         "1_STANDARD_DEVIATION", "2_STANDARD_DEVIATIONS", "3_STANDARD_DEVIATIONS"
-    ] = "1_STANDARD_DEVIATION"
-    weight_field: Optional[str] = Field(default=None, max_length=64)
+    ] = Field(
+        default="1_STANDARD_DEVIATION",
+        description=(
+            "Size of the standard deviational ellipse to create. Use "
+            "1_STANDARD_DEVIATION for the core distribution, or larger values "
+            "to show broader spread around the mean center."
+        ),
+    )
+    weight_field: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Optional numeric field used to weight features when calculating "
+            "direction, dispersion, and ellipse size. Use None for unweighted "
+            "directional distribution."
+        ),
+    )
 
 
 class KernelDensityInput(ToolInput):
-    in_features: str
-    out_raster: str
+    """Input contract for estimating a continuous density raster from features."""
+
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to point or polyline features used as density inputs. "
+            "The path must be inside a configured PathGuard allowed root."
+        ),
+    )
+    out_raster: str = Field(
+        ...,
+        description=(
+            "Absolute output raster path to create with density values. Existing "
+            "outputs require overwrite=true."
+        ),
+    )
     population_field: str = Field(
         default="NONE",
         max_length=64,
-        description="Count/weight field; 'NONE' weights every feature as 1.",
+        description=(
+            "Optional count or weight field used to scale each input feature's "
+            "contribution to density. Use 'NONE' to weight every feature as 1."
+        ),
     )
-    cell_size: Optional[float] = Field(default=None, gt=0)
+    cell_size: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional output raster cell size in map units. Use None to let ArcPy "
+            "choose a default based on input extent and data."
+        ),
+    )
     search_radius: Optional[float] = Field(
-        default=None, gt=0, description="Bandwidth in map units; None = default."
+        default=None,
+        gt=0,
+        description=(
+            "Optional kernel bandwidth or search radius in map units. Larger "
+            "values create smoother density surfaces; use None for ArcPy's default."
+        ),
     )
-    overwrite: bool = False
+    overwrite: bool = Field(
+        default=False,
+        description="Set true only when replacing an existing output raster is intended.",
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {
         "in_features": "read",
         "out_raster": "write",
@@ -64,28 +150,95 @@ class KernelDensityInput(ToolInput):
 
 
 class HotspotAnalysisInput(StatsInOut):
+    """Input contract for identifying statistically significant hot and cold spots."""
+
     input_field: str = Field(
         ...,
         min_length=1,
         max_length=64,
-        description="Numeric field analyzed for clustering.",
+        description=(
+            "Numeric attribute field analyzed for statistically significant spatial "
+            "clustering of high and low values."
+        ),
     )
-    conceptualization: Conceptualization = "FIXED_DISTANCE_BAND"
-    distance_method: DistanceMethod = "EUCLIDEAN_DISTANCE"
+    conceptualization: Conceptualization = Field(
+        default="FIXED_DISTANCE_BAND",
+        description=(
+            "Spatial relationship model used to define feature neighbors, such as "
+            "FIXED_DISTANCE_BAND, INVERSE_DISTANCE, K_NEAREST_NEIGHBORS, or "
+            "contiguity-based relationships."
+        ),
+    )
+    distance_method: DistanceMethod = Field(
+        default="EUCLIDEAN_DISTANCE",
+        description=(
+            "Distance calculation method used for spatial relationships. Use "
+            "EUCLIDEAN_DISTANCE for straight-line distance or MANHATTAN_DISTANCE "
+            "for grid-like movement."
+        ),
+    )
     distance_band: Optional[float] = Field(
-        default=None, gt=0, description="Band/threshold in map units."
+        default=None,
+        gt=0,
+        description=(
+            "Optional distance threshold in map units used by distance-based "
+            "conceptualizations. Use None when ArcPy should infer or not require "
+            "a distance band."
+        ),
     )
 
 
 class SpatialAutocorrelationInput(ToolInput):
-    """Global Moran's I — returns scalar statistics, writes no dataset."""
+    """Input contract for Global Moran's I, returning scalar statistics only."""
 
-    in_features: str
-    input_field: str = Field(..., min_length=1, max_length=64)
-    conceptualization: Conceptualization = "INVERSE_DISTANCE"
-    distance_method: DistanceMethod = "EUCLIDEAN_DISTANCE"
-    standardization: Literal["NONE", "ROW"] = "ROW"
-    distance_band: Optional[float] = Field(default=None, gt=0)
+    in_features: str = Field(
+        ...,
+        description=(
+            "Absolute path to the input feature class whose spatial autocorrelation "
+            "will be measured. The path must be inside a configured PathGuard "
+            "allowed root."
+        ),
+    )
+    input_field: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "Numeric attribute field used to calculate Global Moran's I spatial "
+            "autocorrelation statistics."
+        ),
+    )
+    conceptualization: Conceptualization = Field(
+        default="INVERSE_DISTANCE",
+        description=(
+            "Spatial relationship model used to define feature neighbors, such as "
+            "INVERSE_DISTANCE, FIXED_DISTANCE_BAND, K_NEAREST_NEIGHBORS, or "
+            "contiguity-based relationships."
+        ),
+    )
+    distance_method: DistanceMethod = Field(
+        default="EUCLIDEAN_DISTANCE",
+        description=(
+            "Distance calculation method used for spatial weights. Use "
+            "EUCLIDEAN_DISTANCE for straight-line distance or MANHATTAN_DISTANCE "
+            "for grid-like movement."
+        ),
+    )
+    standardization: Literal["NONE", "ROW"] = Field(
+        default="ROW",
+        description=(
+            "Spatial weights standardization method. ROW standardizes neighbor "
+            "weights by row; NONE uses raw weights."
+        ),
+    )
+    distance_band: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional distance threshold in map units used for distance-based "
+            "spatial relationships. Use None when no explicit threshold is needed."
+        ),
+    )
     path_fields: ClassVar[dict[str, PathRole]] = {"in_features": "read"}
 
 

--- a/arcgis_mcp/tools/geometry.py
+++ b/arcgis_mcp/tools/geometry.py
@@ -530,11 +530,14 @@ _SPECS = (
     (
         "create_fishnet",
         (
-            "Create a regular rectangular grid or fishnet feature class using "
-            "ArcPy CreateFishnet. Use this to build sampling grids, analysis "
-            "cells, index maps, planning units, or raster-like vector zones from "
-            "an origin, cell size, row/column count, and geometry type. Writes a "
-            "new grid dataset inside a PathGuard allowed root."
+            "Create a rectangular fishnet or grid feature class using ArcPy "
+            "CreateFishnet from explicit origin coordinates, optional Y-axis "
+            "orientation, cell width, cell height, row count, column count, label "
+            "point option, and output geometry type. Use this to generate sampling "
+            "grids, planning units, analysis zones, index maps, polygon tiles, or "
+            "polyline grid overlays before spatial join, summarize-within, raster "
+            "conversion, QA/QC, or map production. Writes out_features inside a "
+            "PathGuard allowed root; existing outputs require overwrite=true."
         ),
         c.CreateFishnetInput,
         _create_fishnet,

--- a/arcgis_mcp/tools/map_mgmt.py
+++ b/arcgis_mcp/tools/map_mgmt.py
@@ -156,8 +156,14 @@ register(
     ToolSpec(
         "add_layer_to_map",
         _CAT,
-        "Add a dataset to a map inside an .aprx project (arcpy.mp addDataFromPath). "
-        "Operates on the saved project file, not a live Pro session.",
+        (
+            "Add a dataset to a map inside a saved ArcGIS Pro .aprx project using "
+            "arcpy.mp addDataFromPath. Use this to load feature classes, rasters, "
+            "tables, or other supported GIS datasets into an existing project map "
+            "before styling, exporting, or layout automation. Operates on the saved "
+            ".aprx file, not a live ArcGIS Pro session, and saves the project when "
+            "save=true."
+        ),
         c.AddLayerToMapInput,
         _add_layer_to_map,
     )
@@ -166,7 +172,13 @@ register(
     ToolSpec(
         "remove_layer_from_map",
         _CAT,
-        "Remove a layer from a map (map.removeLayer). Requires confirm=true.",
+        (
+            "Remove a named layer from a map inside a saved ArcGIS Pro .aprx project "
+            "using map.removeLayer. Use this for controlled map cleanup before "
+            "export, packaging, or automated project updates. This changes the map "
+            "contents but does not delete the underlying dataset; confirm=true is "
+            "required because the project structure is mutated."
+        ),
         c.RemoveLayerFromMapInput,
         _remove_layer_from_map,
         destructive=True,
@@ -176,7 +188,12 @@ register(
     ToolSpec(
         "list_maps",
         _CAT,
-        "List all map names inside an .aprx project (aprx.listMaps).",
+        (
+            "List map names inside a saved ArcGIS Pro .aprx project using "
+            "aprx.listMaps. Use this discovery tool before map-scoped operations "
+            "when the target map name is unknown or when validating project contents. "
+            "Reads the project file only and does not modify or save it."
+        ),
         c.ListMapsInput,
         _list_maps,
     )
@@ -185,7 +202,13 @@ register(
     ToolSpec(
         "list_layers_in_map",
         _CAT,
-        "List layers of one map with visibility, group flag and data source.",
+        (
+            "List layers in a selected map with visibility, group-layer status, and "
+            "data source information where available. Use this to discover exact "
+            "Contents-pane layer names before visibility, ordering, symbology, rename, "
+            "or zoom operations. Reads the saved .aprx project only and does not "
+            "modify layer state."
+        ),
         c.ListLayersInMapInput,
         _list_layers_in_map,
     )
@@ -194,7 +217,12 @@ register(
     ToolSpec(
         "set_layer_visibility",
         _CAT,
-        "Show or hide a layer (lyr.visible).",
+        (
+            "Show or hide a named layer in a selected ArcGIS Pro map by updating "
+            "lyr.visible. Use this before layout or map export to control which "
+            "datasets appear in the final map. This mutates layer visibility in the "
+            "saved .aprx project when save=true but does not alter the source dataset."
+        ),
         c.SetLayerVisibilityInput,
         _set_layer_visibility,
     )
@@ -203,8 +231,12 @@ register(
     ToolSpec(
         "move_layer_order",
         _CAT,
-        "Change draw order: move a layer BEFORE/AFTER a reference layer "
-        "(map.moveLayer).",
+        (
+            "Move a named layer before or after a reference layer in the map drawing "
+            "order using map.moveLayer. Use this to control cartographic stacking, "
+            "for example placing boundaries above imagery or analysis results above "
+            "base layers. This updates the saved .aprx project when save=true."
+        ),
         c.MoveLayerOrderInput,
         _move_layer_order,
     )
@@ -213,7 +245,12 @@ register(
     ToolSpec(
         "rename_layer",
         _CAT,
-        "Rename a layer as shown in the Contents pane (lyr.name).",
+        (
+            "Rename a layer as displayed in the ArcGIS Pro Contents pane by updating "
+            "lyr.name. Use this to make automated map outputs clearer before export, "
+            "handoff, or presentation. This renames the map layer only, does not "
+            "rename the underlying dataset, and saves the .aprx project when save=true."
+        ),
         c.RenameLayerInput,
         _rename_layer,
     )
@@ -222,7 +259,13 @@ register(
     ToolSpec(
         "zoom_to_layer",
         _CAT,
-        "Set the map's default camera to a layer's extent.",
+        (
+            "Set the selected map's default camera extent to match a named layer's "
+            "data extent. Use this before exporting a map view or reopening the "
+            ".aprx so the map focuses on a study area, boundary, analysis result, "
+            "or target dataset. Reads the layer data source extent, updates the map "
+            "defaultCamera, and saves the project when save=true."
+        ),
         c.ZoomToLayerInput,
         _zoom_to_layer,
     )
@@ -231,7 +274,13 @@ register(
     ToolSpec(
         "set_layer_symbology",
         _CAT,
-        "Apply symbology from a .lyrx file (ApplySymbologyFromLayer).",
+        (
+            "Apply cartographic symbology from a source .lyrx layer file to a named "
+            "target layer using ArcPy ApplySymbologyFromLayer. Use this to standardize "
+            "colors, classifications, labels, renderers, and map styling before export "
+            "or project delivery. Reads the target layer and .lyrx file inside "
+            "PathGuard allowed roots and saves the .aprx project when save=true."
+        ),
         c.SetLayerSymbologyInput,
         _set_layer_symbology,
     )
@@ -240,7 +289,13 @@ register(
     ToolSpec(
         "save_project",
         _CAT,
-        "Save the .aprx project file (aprx.save).",
+        (
+            "Explicitly save a saved ArcGIS Pro .aprx project using aprx.save. Use "
+            "this after a sequence of map, layer, layout, visibility, camera, or "
+            "symbology changes when the project must be persisted before export or "
+            "handoff. Operates on the saved .aprx file and returns the saved project "
+            "path."
+        ),
         c.SaveProjectInput,
         _save_project,
     )

--- a/arcgis_mcp/tools/network_analysis.py
+++ b/arcgis_mcp/tools/network_analysis.py
@@ -129,29 +129,52 @@ _CAT = Category.NETWORK
 _SPECS = (
     (
         "service_area",
-        "Reachable-area polygons around facilities at travel cutoffs "
-        "(MakeServiceAreaAnalysisLayer). Requires Network Analyst.",
+        (
+            "Solve reachable service area polygons around facility points using "
+            "ArcPy Network Analyst MakeServiceAreaAnalysisLayer. Use this to map "
+            "accessibility around schools, hospitals, stations, depots, stores, "
+            "or emergency facilities at one or more travel cutoffs. Requires a "
+            "Network Analyst license; reads a network_dataset and facilities, then "
+            "writes solved polygon features to out_features inside PathGuard roots."
+        ),
         c.ServiceAreaInput,
         _service_area,
     ),
     (
         "route_analysis",
-        "Best route through ordered stops (MakeRouteAnalysisLayer). "
-        "Requires Network Analyst.",
+        (
+            "Solve the best route through ordered stop points using ArcPy Network "
+            "Analyst MakeRouteAnalysisLayer. Use this for A-to-B routing, multi-stop "
+            "field visits, logistics paths, inspection sequences, or travel-time "
+            "analysis over a configured network dataset. Requires a Network Analyst "
+            "license; reads stops and writes solved route features to out_features."
+        ),
         c.RouteAnalysisInput,
         _route_analysis,
     ),
     (
         "od_cost_matrix",
-        "Origin-destination cost matrix lines (MakeODCostMatrixAnalysisLayer). "
-        "Requires Network Analyst.",
+        (
+            "Solve origin-destination travel cost lines using ArcPy Network Analyst "
+            "MakeODCostMatrixAnalysisLayer. Use this to measure travel time or "
+            "distance between demand points and destinations such as services, jobs, "
+            "facilities, stores, or transit stops. Requires a Network Analyst license; "
+            "supports travel_mode and optional cutoff, then writes OD line results "
+            "to out_features inside PathGuard allowed roots."
+        ),
         c.OdCostMatrixInput,
         _od_cost_matrix,
     ),
     (
         "closest_facility",
-        "Nearest facility routes per incident (MakeClosestFacilityAnalysisLayer). "
-        "Requires Network Analyst.",
+        (
+            "Find nearest facility routes for incident points using ArcPy Network "
+            "Analyst MakeClosestFacilityAnalysisLayer. Use this to match demand or "
+            "incident locations to hospitals, stations, schools, depots, stores, or "
+            "other candidate facilities by network travel cost. Requires a Network "
+            "Analyst license; supports facilities_to_find and writes solved route "
+            "features to out_features."
+        ),
         c.ClosestFacilityInput,
         _closest_facility,
     ),

--- a/arcgis_mcp/tools/projection.py
+++ b/arcgis_mcp/tools/projection.py
@@ -94,8 +94,14 @@ register(
     ToolSpec(
         "define_projection",
         _CAT,
-        "Assign a CRS (by WKID/EPSG) to a dataset with an unknown spatial "
-        "reference (DefineProjection). Metadata-only; requires confirm=true.",
+        (
+            "Assign coordinate reference metadata to an existing dataset using "
+            "ArcPy DefineProjection and a WKID or EPSG code. Use this only when "
+            "the dataset coordinates are already in the specified CRS but the "
+            "spatial reference is missing or unknown. This is metadata-only, does "
+            "not transform coordinates, mutates the dataset definition, and "
+            "requires confirm=true."
+        ),
         c.DefineProjectionInput,
         _define_projection,
         destructive=True,
@@ -105,7 +111,14 @@ register(
     ToolSpec(
         "project_features",
         _CAT,
-        "Transform a vector dataset into another CRS/datum (Project).",
+        (
+            "Transform a vector feature class or layer into another coordinate "
+            "reference system using ArcPy Project. Use this when feature geometry "
+            "coordinates must be reprojected for overlay, distance measurement, "
+            "map export, analysis, or alignment with other GIS datasets. Reads "
+            "in_features, writes out_features inside PathGuard allowed roots, and "
+            "supports an optional geographic transform_method when datums differ."
+        ),
         c.ProjectFeaturesInput,
         _project_features,
     )
@@ -114,7 +127,13 @@ register(
     ToolSpec(
         "get_spatial_reference",
         _CAT,
-        "Look up a CRS by WKID: name, type, linear/angular units, datum.",
+        (
+            "Look up an ArcGIS spatial reference by WKID or EPSG code using "
+            "arcpy.SpatialReference. Use this before projection workflows to "
+            "verify the target CRS name, type, datum, and linear or angular units. "
+            "This is a pure lookup with no filesystem input or output and does "
+            "not modify datasets."
+        ),
         c.GetSpatialReferenceInput,
         _get_spatial_reference,
     )
@@ -123,8 +142,14 @@ register(
     ToolSpec(
         "project_raster",
         _CAT,
-        "Reproject a raster with NEAREST/BILINEAR/CUBIC/MAJORITY resampling "
-        "(ProjectRaster).",
+        (
+            "Reproject a raster dataset into another coordinate reference system "
+            "using ArcPy ProjectRaster. Use this to align DEMs, imagery, classified "
+            "rasters, or analysis grids with a project CRS before overlay, map "
+            "algebra, extraction, or export. Reads in_raster, writes out_raster "
+            "inside PathGuard allowed roots, and exposes resampling_type and "
+            "optional cell_size for controlling raster cell interpolation."
+        ),
         c.ProjectRasterInput,
         _project_raster,
     )

--- a/arcgis_mcp/tools/spatial_stats.py
+++ b/arcgis_mcp/tools/spatial_stats.py
@@ -104,33 +104,66 @@ _CAT = Category.SPATIAL_STATS
 _SPECS = (
     (
         "mean_center",
-        "Geometric mean center of features, optionally weighted (MeanCenter).",
+        (
+            "Calculate the geographic mean center of input features using ArcPy "
+            "MeanCenter and write the result as a point feature class. Use this "
+            "to summarize the central tendency of incidents, facilities, parcels, "
+            "demand points, or grouped spatial observations. Supports optional "
+            "weight_field and case_field parameters; reads in_features and writes "
+            "out_features inside PathGuard allowed roots."
+        ),
         c.MeanCenterInput,
         _mean_center,
     ),
     (
         "directional_distribution",
-        "Standard deviational ellipse of a point distribution "
-        "(DirectionalDistribution).",
+        (
+            "Create standard deviational ellipse features using ArcPy "
+            "DirectionalDistribution to summarize spatial orientation, dispersion, "
+            "and directional trend. Use this for point-pattern analysis, movement "
+            "corridors, incident spread, market/service-area orientation, or "
+            "comparison between groups. Supports ellipse_size and optional "
+            "weight_field; writes a new output feature class without modifying inputs."
+        ),
         c.DirectionalDistributionInput,
         _directional_distribution,
     ),
     (
         "kernel_density",
-        "Kernel density surface from points/lines (sa.KernelDensity). "
-        "Requires Spatial Analyst.",
+        (
+            "Estimate a continuous density raster from point or polyline features "
+            "using Spatial Analyst KernelDensity. Use this for hotspot surfaces, "
+            "incident intensity, service demand, accessibility pressure, crime or "
+            "event density, and other smoothed spatial concentration maps. Requires "
+            "a Spatial Analyst license; supports population_field, cell_size, and "
+            "search_radius and writes out_raster inside PathGuard roots."
+        ),
         c.KernelDensityInput,
         _kernel_density,
     ),
     (
         "hotspot_analysis",
-        "Getis-Ord Gi* hot/cold spot clustering (HotSpots).",
+        (
+            "Run Getis-Ord Gi* hot and cold spot analysis using ArcPy HotSpots and "
+            "write a feature class with GiZScore, GiPValue, and Gi_Bin results. "
+            "Use this to identify statistically significant clusters of high and "
+            "low values in incidents, socioeconomic indicators, service demand, or "
+            "environmental measurements. Supports spatial conceptualization, "
+            "distance method, and optional distance band."
+        ),
         c.HotspotAnalysisInput,
         _hotspot_analysis,
     ),
     (
         "spatial_autocorrelation",
-        "Global Moran's I index, z-score and p-value (SpatialAutocorrelation).",
+        (
+            "Calculate Global Moran's I using ArcPy SpatialAutocorrelation and "
+            "return scalar statistics including Moran's Index, z-score, and p-value. "
+            "Use this to test whether a numeric attribute is clustered, dispersed, "
+            "or spatially random before choosing local hotspot, cluster, or spatial "
+            "modeling workflows. Reads in_features only and does not create or "
+            "modify datasets."
+        ),
         c.SpatialAutocorrelationInput,
         _spatial_autocorrelation,
     ),


### PR DESCRIPTION
## Summary

This PR improves MCP tool definition quality for the remaining lower-scoring Glama tools.

Focused tools:
- spatial statistics: `mean_center`, `directional_distribution`, `kernel_density`, `hotspot_analysis`
- map management: `set_layer_symbology`, `zoom_to_layer`, `save_project`
- projection: `project_features`, `project_raster`
- network analysis: `od_cost_matrix`, `service_area`
- geometry: `create_fishnet`

The changes expand ToolSpec descriptions and input field descriptions so tools are clearer about:
- purpose and GIS use cases
- behavior and side effects
- input/output paths and PathGuard expectations
- license requirements where relevant
- important parameters and output semantics

No runtime behavior was changed.

## Validation

```powershell
uv run ruff check .
uv run mypy
uv run pytest