### PR TITLE
Add reproducible ArcGIS Pro runtime benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Technical write-up: https://dev.to/muend/building-a-secure-mcp-bridge-for-arcgis
 | | |
 |---|---|
 | Catalog | 100 tools · 10 verticals |
-| Tests | 85 unit tests · 85/85 passing · arcpy mocked |
+| Tests | 86 unit tests · 86/86 passing · arcpy mocked |
 | Real runtime evidence | [Reproducible ArcGIS Pro MCP smoke benchmark](benchmarks/) |
 | Static analysis | Ruff clean · Mypy `strict` clean |
 | Transport | JSON-RPC 2.0 over stdio |
@@ -173,7 +173,7 @@ ArcGIS Pro worker and a dedicated scratch GDB; it is not pooled with the mocked
 unit-test count or presented as validation of all 100 geoprocessing tools.
 
 **Scope, stated plainly:** the automated gate currently consists of
-**85 unit tests** spanning the PathGuard boundary, the Pydantic contracts,
+**86 unit tests** spanning the PathGuard boundary, the Pydantic contracts,
 the generic registry path-guard and registration invariants, the worker's
 error-boundary mapping, and `Settings` environment validation. It exercises
 the catalog's structural contracts and every security-critical seam — it does
@@ -228,7 +228,7 @@ make lint            # ruff check, mutates nothing
 make type-check      # mypy --strict over arcgis_mcp/
 make security-audit  # live registry inspection: path roles + confirm gates
 make verify-all      # lint + type-check + security-audit, one gate
-python -m pytest     # 85/85
+python -m pytest     # 86/86
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Technical write-up: https://dev.to/muend/building-a-secure-mcp-bridge-for-arcgis
 | | |
 |---|---|
 | Catalog | 100 tools · 10 verticals |
-| Tests | 81 unit tests · 81/81 passing · arcpy mocked |
+| Tests | 85 unit tests · 85/85 passing · arcpy mocked |
+| Real runtime evidence | [Reproducible ArcGIS Pro MCP smoke benchmark](benchmarks/) |
 | Static analysis | Ruff clean · Mypy `strict` clean |
 | Transport | JSON-RPC 2.0 over stdio |
 | License | Apache-2.0 |
@@ -166,8 +167,13 @@ dunder access) by a contract validator.
 
 ## 03 — Automated Quality Gate & Testing
 
+Licensed-runtime evidence is reported separately in the
+[`benchmarks/`](benchmarks/) method card. Its committed result uses a real
+ArcGIS Pro worker and a dedicated scratch GDB; it is not pooled with the mocked
+unit-test count or presented as validation of all 100 geoprocessing tools.
+
 **Scope, stated plainly:** the automated gate currently consists of
-**81 unit tests** spanning the PathGuard boundary, the Pydantic contracts,
+**85 unit tests** spanning the PathGuard boundary, the Pydantic contracts,
 the generic registry path-guard and registration invariants, the worker's
 error-boundary mapping, and `Settings` environment validation. It exercises
 the catalog's structural contracts and every security-critical seam — it does
@@ -222,7 +228,7 @@ make lint            # ruff check, mutates nothing
 make type-check      # mypy --strict over arcgis_mcp/
 make security-audit  # live registry inspection: path roles + confirm gates
 make verify-all      # lint + type-check + security-audit, one gate
-python -m pytest     # 81/81
+python -m pytest     # 85/85
 ```
 
 ---

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,63 @@
+# ArcGIS Pro runtime benchmark
+
+This directory separates mocked CI coverage from evidence produced by a real,
+licensed ArcGIS Pro runtime. The benchmark is intentionally small: it proves the
+MCP-to-worker pipeline, a non-mutating ArcPy call, a new-output write, follow-up
+inspection, PathGuard rejection, and the destructive confirmation gate.
+
+It does **not** claim that all catalog tools, ArcGIS extensions, platforms, or
+data-dependent geoprocessing workflows have been validated.
+
+## Safety contract
+
+- Run only against a dedicated, existing allowed root and scratch file GDB.
+- The harness sets one allowed root and `ARCGIS_MCP_MAX_WORKERS=1`.
+- Read-only mode never creates a GIS dataset.
+- `--write-check` creates one uniquely named, empty WGS 84 point feature class.
+- The harness never requests overwrite and never sends `confirm=true`.
+- The unconfirmed-delete case must fail; the created artifact is retained.
+- Published JSON replaces all configured local paths with placeholders.
+
+## Run it
+
+Install the bridge into an isolated host environment. Ensure the ArcGIS Pro
+worker interpreter can import both `arcpy` and `arcgis_mcp.worker`, then run:
+
+```powershell
+python -m benchmarks.arcgis_pro_smoke `
+  --arcpy-python "C:\Path\To\arcgispro-py3\python.exe" `
+  --allowed-root "C:\ArcGISBench" `
+  --scratch-gdb "C:\ArcGISBench\scratch.gdb" `
+  --source-commit "$(git rev-parse HEAD)" `
+  --arcgis-pro-version "3.7" `
+  --expected-tool-count 103 `
+  --write-check `
+  --output "benchmarks\results\local.json"
+```
+
+Omit `--write-check` for the four-case read-only condition. A passing write-
+safety run contains eight cases:
+
+1. exact tool-surface discovery;
+2. server-to-worker `health_check`;
+3. ArcPy-backed WGS 84 spatial-reference lookup;
+4. PathGuard rejection of an existing path outside the declared root;
+5. creation of a uniquely named empty point feature class;
+6. description of the created dataset;
+7. a zero-row feature count;
+8. rejection of `delete_dataset` with `confirm=false`.
+
+Exit code `0` means every case matched its expected outcome, `1` means one or
+more cases failed, and `2` means configuration or execution could not start.
+
+## Result contract and interpretation
+
+[`schema.json`](schema.json) is the machine-readable result contract. Results
+report simple unweighted case counts. Per-call wall time includes ArcPy worker
+startup and is retained for diagnostics only; one host run is not a performance
+comparison. Do not pool results across ArcGIS Pro, bridge, FastMCP, Python, or
+hardware versions.
+
+The committed result in [`results/`](results/) is maintainer-generated evidence
+for its exact declared environment and source commit. Reproduce it before making
+claims about a different installation.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible benchmark harnesses for licensed ArcGIS runtimes."""

--- a/benchmarks/arcgis_pro_smoke.py
+++ b/benchmarks/arcgis_pro_smoke.py
@@ -106,12 +106,15 @@ def redact(value: Any, replacements: Sequence[tuple[str, str]]) -> Any:
         return value
 
     redacted = value
+    expanded: list[tuple[str, str]] = []
+    for source, replacement in replacements:
+        expanded.append((source, replacement))
+        if "\\" in source:
+            expanded.append((source.replace("\\", "\\\\"), replacement))
     for source, replacement in sorted(
-        replacements, key=lambda pair: len(pair[0]), reverse=True
+        expanded, key=lambda pair: len(pair[0]), reverse=True
     ):
-        redacted = re.sub(
-            re.escape(source), replacement, redacted, flags=re.IGNORECASE
-        )
+        redacted = re.sub(re.escape(source), replacement, redacted, flags=re.IGNORECASE)
     return redacted
 
 
@@ -198,6 +201,7 @@ async def execute(config: BenchmarkConfig) -> dict[str, Any]:
         (str(config.arcpy_python), "<ARCPY_PYTHON>"),
         (str(config.allowed_root), "<ALLOWED_ROOT>"),
         (str(outside_probe), "<OUTSIDE_ROOT_PROBE>"),
+        (dataset_name, "<DATASET>"),
     ]
 
     async with Client(mcp) as client:

--- a/benchmarks/arcgis_pro_smoke.py
+++ b/benchmarks/arcgis_pro_smoke.py
@@ -1,0 +1,396 @@
+"""Run a safe, reproducible ArcGIS Pro MCP integration benchmark.
+
+The harness uses a dedicated allowed root and an existing scratch geodatabase.
+In write-check mode it creates one uniquely named empty point feature class. It
+never sends a confirmed delete request, overwrites an output, or reads user data.
+Published JSON redacts every configured local path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.metadata
+import json
+import os
+import platform
+import re
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA_VERSION = "1.0.0"
+REQUIRED_TOOLS = frozenset(
+    {
+        "health_check",
+        "get_spatial_reference",
+        "create_feature_class",
+        "describe_dataset",
+        "get_feature_count",
+        "delete_dataset",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Validated inputs and declared runtime provenance."""
+
+    arcpy_python: Path
+    allowed_root: Path
+    scratch_gdb: Path
+    output: Path
+    source_commit: str
+    arcgis_pro_version: str
+    expected_tool_count: int = 103
+    write_check: bool = False
+
+
+def validate_config(config: BenchmarkConfig) -> BenchmarkConfig:
+    """Resolve paths and reject unsafe or unusable benchmark boundaries."""
+    arcpy_python = config.arcpy_python.expanduser().resolve()
+    allowed_root = config.allowed_root.expanduser().resolve()
+    scratch_gdb = config.scratch_gdb.expanduser().resolve()
+    output = config.output.expanduser().resolve()
+
+    if not arcpy_python.is_file():
+        raise ValueError(f"ArcPy interpreter does not exist: {arcpy_python}")
+    if not allowed_root.is_dir():
+        raise ValueError(f"Allowed root does not exist: {allowed_root}")
+    if allowed_root == Path(allowed_root.anchor):
+        raise ValueError("Allowed root must not be a filesystem root")
+    if not scratch_gdb.is_dir() or scratch_gdb.suffix.lower() != ".gdb":
+        raise ValueError(f"Scratch geodatabase does not exist: {scratch_gdb}")
+    if not scratch_gdb.is_relative_to(allowed_root):
+        raise ValueError("Scratch geodatabase must be inside the allowed root")
+    if config.expected_tool_count < len(REQUIRED_TOOLS):
+        raise ValueError("Expected tool count is smaller than the required surface")
+    if not re.fullmatch(r"[0-9a-fA-F]{7,40}", config.source_commit):
+        raise ValueError("Source commit must be a 7-40 character hexadecimal SHA")
+    if not config.arcgis_pro_version.strip():
+        raise ValueError("ArcGIS Pro version must be declared")
+
+    return BenchmarkConfig(
+        arcpy_python=arcpy_python,
+        allowed_root=allowed_root,
+        scratch_gdb=scratch_gdb,
+        output=output,
+        source_commit=config.source_commit.lower(),
+        arcgis_pro_version=config.arcgis_pro_version.strip(),
+        expected_tool_count=config.expected_tool_count,
+        write_check=config.write_check,
+    )
+
+
+def outside_root_probe(allowed_root: Path) -> Path:
+    """Return an existing parent that a one-root PathGuard must reject."""
+    parent = allowed_root.resolve().parent
+    if parent == allowed_root or not parent.exists():
+        raise ValueError("Cannot derive an existing outside-root probe")
+    return parent
+
+
+def redact(value: Any, replacements: Sequence[tuple[str, str]]) -> Any:
+    """Recursively replace local paths without changing evidence structure."""
+    if isinstance(value, dict):
+        return {key: redact(item, replacements) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact(item, replacements) for item in value]
+    if isinstance(value, tuple):
+        return [redact(item, replacements) for item in value]
+    if not isinstance(value, str):
+        return value
+
+    redacted = value
+    for source, replacement in sorted(
+        replacements, key=lambda pair: len(pair[0]), reverse=True
+    ):
+        redacted = re.sub(
+            re.escape(source), replacement, redacted, flags=re.IGNORECASE
+        )
+    return redacted
+
+
+def summarize(cases: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Compute transparent pass/fail counts without weighted aggregation."""
+    passed = sum(case.get("status") == "pass" for case in cases)
+    total = len(cases)
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "pass_rate": round(passed / total, 4) if total else 0.0,
+    }
+
+
+def _result_evidence(result: Any) -> dict[str, Any]:
+    payload = getattr(result, "structured_content", None)
+    if payload is None:
+        payload = getattr(result, "data", None)
+    return {
+        "is_error": bool(getattr(result, "is_error", False)),
+        "payload": payload,
+        "messages": [
+            getattr(item, "text", str(item))
+            for item in getattr(result, "content", [])
+        ],
+    }
+
+
+async def _call_case(
+    client: Any,
+    *,
+    case_id: str,
+    tool: str,
+    arguments: dict[str, Any],
+    expect_error: bool = False,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        result = await client.call_tool(
+            tool, arguments, raise_on_error=False, timeout=240
+        )
+        is_error = bool(getattr(result, "is_error", False))
+        passed = is_error if expect_error else not is_error
+        evidence = _result_evidence(result)
+    except Exception as exc:  # benchmark boundary must preserve partial evidence
+        passed = False
+        evidence = {
+            "is_error": True,
+            "exception_type": type(exc).__name__,
+            "messages": [str(exc)],
+        }
+    return {
+        "id": case_id,
+        "tool": tool,
+        "expected": "error" if expect_error else "success",
+        "status": "pass" if passed else "fail",
+        "wall_seconds": round(time.perf_counter() - started, 3),
+        "evidence": evidence,
+    }
+
+
+async def execute(config: BenchmarkConfig) -> dict[str, Any]:
+    """Execute the declared benchmark condition and return an unsaved report."""
+    benchmark_started = time.perf_counter()
+    os.environ["ARCPY_PYTHON_PATH"] = str(config.arcpy_python)
+    os.environ["ARCGIS_MCP_ALLOWED_ROOTS"] = str(config.allowed_root)
+    os.environ["ARCGIS_MCP_SCRATCH_GDB"] = str(config.scratch_gdb)
+    os.environ["ARCGIS_MCP_MAX_WORKERS"] = "1"
+    os.environ.setdefault("ARCGIS_MCP_TOOL_TIMEOUT", "180")
+
+    from fastmcp import Client
+
+    from arcgis_mcp.server import mcp
+
+    cases: list[dict[str, Any]] = []
+    outside_probe = outside_root_probe(config.allowed_root)
+    dataset_name = f"benchmark_point_{uuid.uuid4().hex[:8]}"
+    dataset_path = config.scratch_gdb / dataset_name
+
+    replacements = [
+        (str(dataset_path), "<SCRATCH_GDB>/<DATASET>"),
+        (str(config.scratch_gdb), "<SCRATCH_GDB>"),
+        (str(config.arcpy_python), "<ARCPY_PYTHON>"),
+        (str(config.allowed_root), "<ALLOWED_ROOT>"),
+        (str(outside_probe), "<OUTSIDE_ROOT_PROBE>"),
+    ]
+
+    async with Client(mcp) as client:
+        started = time.perf_counter()
+        tools = await client.list_tools()
+        tool_names = {tool.name for tool in tools}
+        missing = sorted(REQUIRED_TOOLS - tool_names)
+        discovered = len(tools)
+        cases.append(
+            {
+                "id": "discover-tool-surface",
+                "tool": "tools/list",
+                "expected": f"{config.expected_tool_count} tools and required names",
+                "status": (
+                    "pass"
+                    if discovered == config.expected_tool_count and not missing
+                    else "fail"
+                ),
+                "wall_seconds": round(time.perf_counter() - started, 3),
+                "evidence": {
+                    "discovered_tool_count": discovered,
+                    "required_tools": sorted(REQUIRED_TOOLS),
+                    "missing_required_tools": missing,
+                },
+            }
+        )
+
+        cases.append(
+            await _call_case(
+                client,
+                case_id="health-check",
+                tool="health_check",
+                arguments={},
+            )
+        )
+        cases.append(
+            await _call_case(
+                client,
+                case_id="arcpy-spatial-reference",
+                tool="get_spatial_reference",
+                arguments={"params": {"wkid": 4326}},
+            )
+        )
+        cases.append(
+            await _call_case(
+                client,
+                case_id="outside-root-rejected",
+                tool="describe_dataset",
+                arguments={"params": {"dataset": str(outside_probe)}},
+                expect_error=True,
+            )
+        )
+
+        if config.write_check:
+            cases.append(
+                await _call_case(
+                    client,
+                    case_id="create-empty-feature-class",
+                    tool="create_feature_class",
+                    arguments={
+                        "params": {
+                            "out_gdb": str(config.scratch_gdb),
+                            "name": dataset_name,
+                            "geometry_type": "POINT",
+                            "wkid": 4326,
+                            "overwrite": False,
+                        }
+                    },
+                )
+            )
+            cases.append(
+                await _call_case(
+                    client,
+                    case_id="describe-created-dataset",
+                    tool="describe_dataset",
+                    arguments={"params": {"dataset": str(dataset_path)}},
+                )
+            )
+            cases.append(
+                await _call_case(
+                    client,
+                    case_id="count-created-dataset",
+                    tool="get_feature_count",
+                    arguments={"params": {"dataset": str(dataset_path)}},
+                )
+            )
+            cases.append(
+                await _call_case(
+                    client,
+                    case_id="unconfirmed-delete-rejected",
+                    tool="delete_dataset",
+                    arguments={
+                        "params": {
+                            "dataset": str(dataset_path),
+                            "confirm": False,
+                        }
+                    },
+                    expect_error=True,
+                )
+            )
+
+    cases = redact(cases, replacements)
+    summary = summarize(cases)
+    summary["wall_seconds"] = round(time.perf_counter() - benchmark_started, 3)
+    health_worker_python = next(
+        (
+            case.get("evidence", {}).get("payload", {}).get("worker_python")
+            for case in cases
+            if case.get("id") == "health-check"
+            and isinstance(case.get("evidence", {}).get("payload"), dict)
+        ),
+        None,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "benchmark": "arcgis-pro-mcp-smoke",
+        "condition": "write-safety" if config.write_check else "read-only",
+        "status": "pass" if summary["failed"] == 0 else "fail",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "environment": {
+            "source_commit": config.source_commit,
+            "arcgis_mcp_bridge": importlib.metadata.version("arcgis-mcp-bridge"),
+            "fastmcp": importlib.metadata.version("fastmcp"),
+            "arcgis_pro": config.arcgis_pro_version,
+            "host_python": platform.python_version(),
+            "worker_python": health_worker_python,
+            "platform": platform.system(),
+            "expected_tool_count": config.expected_tool_count,
+            "max_workers": 1,
+        },
+        "safety": {
+            "allowed_root": "<ALLOWED_ROOT>",
+            "scratch_gdb": "<SCRATCH_GDB>",
+            "overwrite_requested": False,
+            "confirmed_delete_requested": False,
+            "created_artifact": (
+                "<SCRATCH_GDB>/<DATASET>" if config.write_check else None
+            ),
+        },
+        "summary": summary,
+        "cases": cases,
+        "limitations": [
+            "Single-host integration evidence; not a portability benchmark.",
+            "ArcGIS extension-dependent tools are outside this smoke condition.",
+            "Case latency includes worker startup and is descriptive, not comparative.",
+            "The created empty feature class is retained; no confirmed delete is sent.",
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arcpy-python", type=Path, required=True)
+    parser.add_argument("--allowed-root", type=Path, required=True)
+    parser.add_argument("--scratch-gdb", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--arcgis-pro-version", required=True)
+    parser.add_argument("--expected-tool-count", type=int, default=103)
+    parser.add_argument(
+        "--write-check",
+        action="store_true",
+        help="Create one uniquely named empty point feature class; never delete it.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        config = validate_config(
+            BenchmarkConfig(
+                arcpy_python=args.arcpy_python,
+                allowed_root=args.allowed_root,
+                scratch_gdb=args.scratch_gdb,
+                output=args.output,
+                source_commit=args.source_commit,
+                arcgis_pro_version=args.arcgis_pro_version,
+                expected_tool_count=args.expected_tool_count,
+                write_check=args.write_check,
+            )
+        )
+        report = asyncio.run(execute(config))
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"benchmark configuration/execution failed: {exc}", file=sys.stderr)
+        return 2
+
+    config.output.parent.mkdir(parents=True, exist_ok=True)
+    config.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report["summary"], indent=2))
+    print(f"result: {config.output}")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results/arcgis-pro-3.7-windows-2026-07-20.json
+++ b/benchmarks/results/arcgis-pro-3.7-windows-2026-07-20.json
@@ -1,0 +1,199 @@
+{
+  "schema_version": "1.0.0",
+  "benchmark": "arcgis-pro-mcp-smoke",
+  "condition": "write-safety",
+  "status": "pass",
+  "generated_at": "2026-07-20T09:51:51.518278+00:00",
+  "environment": {
+    "source_commit": "95ca0ccccbf976b87cbe4d044304f541e941bd4f",
+    "arcgis_mcp_bridge": "0.1.0.dev1+unknown.gc4415d885.d20260720",
+    "fastmcp": "3.4.2",
+    "arcgis_pro": "3.7",
+    "host_python": "3.11.15",
+    "worker_python": "3.13.13",
+    "platform": "Windows",
+    "expected_tool_count": 103,
+    "max_workers": 1
+  },
+  "safety": {
+    "allowed_root": "<ALLOWED_ROOT>",
+    "scratch_gdb": "<SCRATCH_GDB>",
+    "overwrite_requested": false,
+    "confirmed_delete_requested": false,
+    "created_artifact": "<SCRATCH_GDB>/<DATASET>"
+  },
+  "summary": {
+    "total": 8,
+    "passed": 8,
+    "failed": 0,
+    "pass_rate": 1.0,
+    "wall_seconds": 44.952
+  },
+  "cases": [
+    {
+      "id": "discover-tool-surface",
+      "tool": "tools/list",
+      "expected": "103 tools and required names",
+      "status": "pass",
+      "wall_seconds": 0.006,
+      "evidence": {
+        "discovered_tool_count": 103,
+        "required_tools": [
+          "create_feature_class",
+          "delete_dataset",
+          "describe_dataset",
+          "get_feature_count",
+          "get_spatial_reference",
+          "health_check"
+        ],
+        "missing_required_tools": []
+      }
+    },
+    {
+      "id": "health-check",
+      "tool": "health_check",
+      "expected": "success",
+      "status": "pass",
+      "wall_seconds": 1.177,
+      "evidence": {
+        "is_error": false,
+        "payload": {
+          "server": "ok",
+          "worker_python": "3.13.13",
+          "worker_interpreter": "<ARCPY_PYTHON>",
+          "allowed_roots": [
+            "<ALLOWED_ROOT>"
+          ],
+          "scratch_gdb": "<SCRATCH_GDB>",
+          "tool_timeout_s": 180,
+          "max_workers": 1
+        },
+        "messages": [
+          "{\n  \"server\": \"ok\",\n  \"worker_python\": \"3.13.13\",\n  \"worker_interpreter\": \"<ARCPY_PYTHON>\",\n  \"allowed_roots\": [\n    \"<ALLOWED_ROOT>\"\n  ],\n  \"scratch_gdb\": \"<SCRATCH_GDB>\",\n  \"tool_timeout_s\": 180,\n  \"max_workers\": 1\n}"
+        ]
+      }
+    },
+    {
+      "id": "arcpy-spatial-reference",
+      "tool": "get_spatial_reference",
+      "expected": "success",
+      "status": "pass",
+      "wall_seconds": 9.77,
+      "evidence": {
+        "is_error": false,
+        "payload": {
+          "factory_code": 4326,
+          "name": "GCS_WGS_1984",
+          "type": "Geographic",
+          "linear_unit": null,
+          "angular_unit": "Degree",
+          "datum": "D_WGS_1984",
+          "tool": "get_spatial_reference",
+          "elapsed_seconds": 0.026
+        },
+        "messages": [
+          "{\n  \"factory_code\": 4326,\n  \"name\": \"GCS_WGS_1984\",\n  \"type\": \"Geographic\",\n  \"linear_unit\": null,\n  \"angular_unit\": \"Degree\",\n  \"datum\": \"D_WGS_1984\",\n  \"tool\": \"get_spatial_reference\",\n  \"elapsed_seconds\": 0.026\n}"
+        ]
+      }
+    },
+    {
+      "id": "outside-root-rejected",
+      "tool": "describe_dataset",
+      "expected": "error",
+      "status": "pass",
+      "wall_seconds": 0.006,
+      "evidence": {
+        "is_error": true,
+        "payload": null,
+        "messages": [
+          "Error executing tool describe_dataset: [validation] Path <OUTSIDE_ROOT_PROBE> is outside every allowed workspace root."
+        ]
+      }
+    },
+    {
+      "id": "create-empty-feature-class",
+      "tool": "create_feature_class",
+      "expected": "success",
+      "status": "pass",
+      "wall_seconds": 11.557,
+      "evidence": {
+        "is_error": false,
+        "payload": {
+          "created": "<SCRATCH_GDB>/<DATASET>",
+          "geometry_type": "POINT",
+          "wkid": 4326,
+          "tool": "create_feature_class",
+          "elapsed_seconds": 3.56
+        },
+        "messages": [
+          "{\n  \"created\": \"<SCRATCH_GDB>/<DATASET>\",\n  \"geometry_type\": \"POINT\",\n  \"wkid\": 4326,\n  \"tool\": \"create_feature_class\",\n  \"elapsed_seconds\": 3.56\n}"
+        ]
+      }
+    },
+    {
+      "id": "describe-created-dataset",
+      "tool": "describe_dataset",
+      "expected": "success",
+      "status": "pass",
+      "wall_seconds": 8.901,
+      "evidence": {
+        "is_error": false,
+        "payload": {
+          "name": "<DATASET>",
+          "data_type": "FeatureClass",
+          "shape_type": "Point",
+          "crs": "EPSG:4326",
+          "extent": {
+            "xmin": null,
+            "ymin": null,
+            "xmax": null,
+            "ymax": null
+          },
+          "tool": "describe_dataset",
+          "elapsed_seconds": 0.768
+        },
+        "messages": [
+          "{\n  \"name\": \"<DATASET>\",\n  \"data_type\": \"FeatureClass\",\n  \"shape_type\": \"Point\",\n  \"crs\": \"EPSG:4326\",\n  \"extent\": {\n    \"xmin\": null,\n    \"ymin\": null,\n    \"xmax\": null,\n    \"ymax\": null\n  },\n  \"tool\": \"describe_dataset\",\n  \"elapsed_seconds\": 0.768\n}"
+        ]
+      }
+    },
+    {
+      "id": "count-created-dataset",
+      "tool": "get_feature_count",
+      "expected": "success",
+      "status": "pass",
+      "wall_seconds": 8.885,
+      "evidence": {
+        "is_error": false,
+        "payload": {
+          "count": 0,
+          "tool": "get_feature_count",
+          "elapsed_seconds": 1.345
+        },
+        "messages": [
+          "{\n  \"count\": 0,\n  \"tool\": \"get_feature_count\",\n  \"elapsed_seconds\": 1.345\n}"
+        ]
+      }
+    },
+    {
+      "id": "unconfirmed-delete-rejected",
+      "tool": "delete_dataset",
+      "expected": "error",
+      "status": "pass",
+      "wall_seconds": 0.943,
+      "evidence": {
+        "is_error": true,
+        "payload": null,
+        "messages": [
+          "Error executing tool delete_dataset: [security] delete_dataset is destructive or mutates its input: set confirm=true to proceed."
+        ]
+      }
+    }
+  ],
+  "limitations": [
+    "Single-host integration evidence; not a portability benchmark.",
+    "ArcGIS extension-dependent tools are outside this smoke condition.",
+    "Case latency includes worker startup and is descriptive, not comparative.",
+    "The created empty feature class is retained; no confirmed delete is sent."
+  ]
+}

--- a/benchmarks/schema.json
+++ b/benchmarks/schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/muend/arcgis-mcp-bridge/benchmarks/schema.json",
+  "title": "ArcGIS Pro MCP smoke benchmark result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "benchmark",
+    "condition",
+    "status",
+    "generated_at",
+    "environment",
+    "safety",
+    "summary",
+    "cases",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "benchmark": {"const": "arcgis-pro-mcp-smoke"},
+    "condition": {"enum": ["read-only", "write-safety"]},
+    "status": {"enum": ["pass", "fail"]},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_commit",
+        "arcgis_mcp_bridge",
+        "fastmcp",
+        "arcgis_pro",
+        "host_python",
+        "worker_python",
+        "platform",
+        "expected_tool_count",
+        "max_workers"
+      ],
+      "properties": {
+        "source_commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
+        "arcgis_mcp_bridge": {"type": "string"},
+        "fastmcp": {"type": "string"},
+        "arcgis_pro": {"type": "string"},
+        "host_python": {"type": "string"},
+        "worker_python": {"type": ["string", "null"]},
+        "platform": {"type": "string"},
+        "expected_tool_count": {"type": "integer", "minimum": 1},
+        "max_workers": {"const": 1}
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed_root",
+        "scratch_gdb",
+        "overwrite_requested",
+        "confirmed_delete_requested",
+        "created_artifact"
+      ],
+      "properties": {
+        "allowed_root": {"const": "<ALLOWED_ROOT>"},
+        "scratch_gdb": {"const": "<SCRATCH_GDB>"},
+        "overwrite_requested": {"const": false},
+        "confirmed_delete_requested": {"const": false},
+        "created_artifact": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "passed", "failed", "pass_rate", "wall_seconds"],
+      "properties": {
+        "total": {"type": "integer", "minimum": 1},
+        "passed": {"type": "integer", "minimum": 0},
+        "failed": {"type": "integer", "minimum": 0},
+        "pass_rate": {"type": "number", "minimum": 0, "maximum": 1},
+        "wall_seconds": {"type": "number", "minimum": 0}
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "tool",
+          "expected",
+          "status",
+          "wall_seconds",
+          "evidence"
+        ],
+        "properties": {
+          "id": {"type": "string"},
+          "tool": {"type": "string"},
+          "expected": {"type": "string"},
+          "status": {"enum": ["pass", "fail"]},
+          "wall_seconds": {"type": "number", "minimum": 0},
+          "evidence": {"type": "object"}
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string"}
+    }
+  }
+}

--- a/tests/test_arcgis_pro_benchmark.py
+++ b/tests/test_arcgis_pro_benchmark.py
@@ -1,0 +1,78 @@
+"""License-free tests for the real-runtime benchmark harness."""
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmarks.arcgis_pro_smoke import (
+    BenchmarkConfig,
+    outside_root_probe,
+    redact,
+    summarize,
+    validate_config,
+)
+
+
+def _config(tmp_path: Path) -> BenchmarkConfig:
+    arcpy_python = tmp_path / "python.exe"
+    arcpy_python.touch()
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    scratch_gdb = allowed_root / "scratch.gdb"
+    scratch_gdb.mkdir()
+    return BenchmarkConfig(
+        arcpy_python=arcpy_python,
+        allowed_root=allowed_root,
+        scratch_gdb=scratch_gdb,
+        output=tmp_path / "result.json",
+        source_commit="c4415d8",
+        arcgis_pro_version="3.7",
+        write_check=True,
+    )
+
+
+def test_validate_config_resolves_safe_paths(tmp_path: Path) -> None:
+    result = validate_config(_config(tmp_path))
+    assert result.allowed_root.is_absolute()
+    assert result.scratch_gdb.is_relative_to(result.allowed_root)
+
+
+def test_validate_config_rejects_scratch_outside_root(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    outside_gdb = tmp_path / "outside.gdb"
+    outside_gdb.mkdir()
+    with pytest.raises(ValueError, match="inside the allowed root"):
+        validate_config(
+            BenchmarkConfig(
+                **{
+                    **config.__dict__,
+                    "scratch_gdb": outside_gdb,
+                }
+            )
+        )
+
+
+def test_outside_probe_and_redaction_are_boundary_safe(tmp_path: Path) -> None:
+    config = validate_config(_config(tmp_path))
+    probe = outside_root_probe(config.allowed_root)
+    assert probe.exists()
+    assert not probe.is_relative_to(config.allowed_root)
+
+    secret = str(config.scratch_gdb / "FeatureA")
+    value = {"path": secret.upper(), "message": f"Rejected {probe}"}
+    result = redact(
+        value,
+        [
+            (secret, "<SCRATCH_GDB>/<DATASET>"),
+            (str(probe), "<OUTSIDE_ROOT_PROBE>"),
+        ],
+    )
+    serialized = json.dumps(result)
+    assert str(tmp_path).lower() not in serialized.lower()
+    assert "<SCRATCH_GDB>/<DATASET>" in serialized
+    assert "<OUTSIDE_ROOT_PROBE>" in serialized
+
+
+def test_summarize_uses_unweighted_case_counts() -> None:
+    result = summarize([{"status": "pass"}, {"status": "fail"}])
+    assert result == {"total": 2, "passed": 1, "failed": 1, "pass_rate": 0.5}

--- a/tests/test_arcgis_pro_benchmark.py
+++ b/tests/test_arcgis_pro_benchmark.py
@@ -59,18 +59,25 @@ def test_outside_probe_and_redaction_are_boundary_safe(tmp_path: Path) -> None:
     assert not probe.is_relative_to(config.allowed_root)
 
     secret = str(config.scratch_gdb / "FeatureA")
-    value = {"path": secret.upper(), "message": f"Rejected {probe}"}
+    escaped_secret = secret.replace("\\", "\\\\")
+    value = {
+        "path": secret.upper(),
+        "message": f'{{"created": "{escaped_secret}"}}; rejected {probe}',
+        "dataset": "benchmark_point_deadbeef",
+    }
     result = redact(
         value,
         [
             (secret, "<SCRATCH_GDB>/<DATASET>"),
             (str(probe), "<OUTSIDE_ROOT_PROBE>"),
+            ("benchmark_point_deadbeef", "<DATASET>"),
         ],
     )
     serialized = json.dumps(result)
     assert str(tmp_path).lower() not in serialized.lower()
     assert "<SCRATCH_GDB>/<DATASET>" in serialized
     assert "<OUTSIDE_ROOT_PROBE>" in serialized
+    assert "<DATASET>" in serialized
 
 
 def test_summarize_uses_unweighted_case_counts() -> None:

--- a/tests/test_arcgis_pro_benchmark.py
+++ b/tests/test_arcgis_pro_benchmark.py
@@ -1,6 +1,7 @@
 """License-free tests for the real-runtime benchmark harness."""
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -83,3 +84,37 @@ def test_outside_probe_and_redaction_are_boundary_safe(tmp_path: Path) -> None:
 def test_summarize_uses_unweighted_case_counts() -> None:
     result = summarize([{"status": "pass"}, {"status": "fail"}])
     assert result == {"total": 2, "passed": 1, "failed": 1, "pass_rate": 0.5}
+
+
+def test_published_result_is_sanitized_and_consistent() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result_path = (
+        root
+        / "benchmarks"
+        / "results"
+        / "arcgis-pro-3.7-windows-2026-07-20.json"
+    )
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    cases = result["cases"]
+    summary = result["summary"]
+
+    assert result["schema_version"] == "1.0.0"
+    assert result["benchmark"] == "arcgis-pro-mcp-smoke"
+    assert result["condition"] == "write-safety"
+    assert result["status"] == "pass"
+    assert re.fullmatch(r"[0-9a-f]{40}", result["environment"]["source_commit"])
+    assert summary["total"] == len(cases) == 8
+    assert summary["passed"] == 8
+    assert summary["failed"] == 0
+    assert summary["pass_rate"] == 1.0
+    assert all(case["status"] == "pass" for case in cases)
+
+    serialized = json.dumps(result).lower()
+    forbidden = (
+        "c:\\\\",
+        "users",
+        "program files",
+        "geoai-arcgis",
+        "benchmark_point_",
+    )
+    assert not any(token in serialized for token in forbidden)


### PR DESCRIPTION
## What changed

- add a reproducible `benchmarks.arcgis_pro_smoke` harness for licensed ArcGIS Pro runtimes
- define a JSON Schema result contract and an explicit benchmark method card
- publish one sanitized ArcGIS Pro 3.7 / Windows write-safety result tied to an exact source commit
- add license-free tests for configuration boundaries, path redaction, summary math, and published-result integrity
- link real-runtime evidence from the README while keeping it separate from mocked CI coverage

## Why

Hosted CI cannot provide ArcPy or an ArcGIS Pro license. The existing unit suite validates contracts, PathGuard, registry invariants, and worker error boundaries with mocked ArcPy, but it cannot prove that the MCP host launches a licensed worker and completes real ArcPy calls. This benchmark adds that evidence without overstating it as validation of all 100 catalog tools.

## Verified result

Exact write-safety condition: **8/8 passed** in **44.952 seconds** on Windows with ArcGIS Pro 3.7, host Python 3.11.15, worker Python 3.13.13, FastMCP 3.4.2, one worker, and 103 discovered MCP tools.

The run verifies tool discovery, `health_check`, an ArcPy-backed WGS 84 lookup, PathGuard rejection, empty feature-class creation, dataset description, zero-row count, and rejection of `delete_dataset` with `confirm=false`.

The harness never requests overwrite or `confirm=true`. It creates only one uniquely named empty feature class inside a dedicated scratch GDB. Published output redacts configured paths and the artifact name.

## Validation

- `uv run --locked ruff check .`
- `uv run --locked mypy arcgis_mcp`
- `uv run --locked pytest -q` — 86 passed
- Draft 2020-12 JSON Schema validation — passed
- local-path and identity leak scan — passed
- real ArcGIS Pro MCP write-safety benchmark — 8/8 passed

## Limitations

This is single-host integration evidence, not a portability or comparative-performance benchmark. Extension-dependent tools and data-dependent workflows remain outside this smoke condition. Per-call latency includes ArcPy worker startup and must not be pooled across environments.
