### PR TITLE
release: prepare MCP Registry publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,66 @@
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/)
 
+## [0.6.5] - 2026-07-30
+
+### Added
+
+- Added the `arcgis-mcp-bridge` console entry point so PyPI and MCP Registry
+  clients can launch the stdio server using the package name.
+
+### Changed
+
+- Updated `server.json` for Official MCP Registry publication.
+- Added the `uvx` runtime hint and explicit PyPI registry metadata.
+- Clarified Windows and licensed ArcGIS Pro runtime requirements.
+- Marked the ArcGIS interpreter and scratch geodatabase inputs as filesystem
+  paths.
+
+[0.6.5]: https://github.com/muend/arcgis-mcp-bridge/compare/v0.6.4...v0.6.5
+
+## [0.6.4] - 2026-07-30
+
+### Added
+
+- Added the reproducible ArcGIS Pro runtime benchmark and its verified
+  ArcGIS Pro 3.7 Windows result.
+- Added benchmark schema validation and automated benchmark tests.
+- Added MCP distribution assets, generated server-card metadata, project
+  identity assets, and GitHub Sponsors configuration.
+
+### Changed
+
+- Updated the locked MCP dependency from `1.27.2` to `1.28.1`.
+- Reworked the Windows installation documentation for systems with multiple
+  Python installations.
+- Made the unified `arcgis-mcp-env` interpreter the recommended configuration
+  for the MCP server and ArcPy worker.
+
+### Fixed
+
+- Added troubleshooting guidance for
+  `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'`.
+- Corrected Windows interpreter examples and Claude Desktop configuration
+  guidance.
+
+[0.6.4]: https://github.com/muend/arcgis-mcp-bridge/compare/v0.6.3...v0.6.4
+
+## [0.6.3] - 2026-07-04
+
+### Added
+
+- Added `server.json` metadata for Official MCP Registry publication.
+- Added `glama.json` metadata for MCP catalog discovery.
+- Added container files for reproducible package and metadata validation.
+
+### Changed
+
+- Expanded MCP tool and input descriptions with GIS-specific usage,
+  measurement, output, safety, and overwrite guidance.
+- Updated registry metadata to release `0.6.3`.
+
+[0.6.3]: https://github.com/muend/arcgis-mcp-bridge/compare/v0.6.2...v0.6.3
+
 ## [0.6.2] — 2026-07-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ vision = ["opencv-python-headless", "numpy"]
 dev = ["ruff", "mypy", "pytest", "pytest-cov"]
 
 [project.scripts]
+arcgis-mcp-bridge = "arcgis_mcp.server:main"
 arcgis-mcp-server = "arcgis_mcp.server:main"
 arcgis-mcp-setup = "arcgis_mcp.setup_env:main"
 

--- a/server.json
+++ b/server.json
@@ -2,17 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.muend/arcgis-mcp-bridge",
   "title": "ArcGIS MCP Bridge",
-  "description": "A secure, local-first MCP server exposing ArcGIS Pro's ArcPy engine over stdio JSON-RPC.",
+  "description": "A secure, local-first MCP server exposing ArcGIS Pro's ArcPy engine on Windows. Requires a licensed ArcGIS Pro installation and a provisioned ArcGIS Python environment.",
   "repository": {
     "url": "https://github.com/muend/arcgis-mcp-bridge",
     "source": "github"
   },
-  "version": "0.6.3",
+  "version": "0.6.5",
   "packages": [
     {
       "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
       "identifier": "arcgis-mcp-bridge",
-      "version": "0.6.3",
+      "version": "0.6.5",
+      "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
       },
@@ -21,7 +23,7 @@
           "name": "ARCPY_PYTHON_PATH",
           "description": "Path to the licensed ArcGIS Pro Python interpreter or cloned arcgis-mcp-env interpreter.",
           "isRequired": true,
-          "format": "string",
+          "format": "filepath",
           "isSecret": false
         },
         {
@@ -35,7 +37,7 @@
           "name": "ARCGIS_MCP_SCRATCH_GDB",
           "description": "Optional default output workspace. If set, it must point to an existing file geodatabase.",
           "isRequired": false,
-          "format": "string",
+          "format": "filepath",
           "isSecret": false
         },
         {


### PR DESCRIPTION
## Summary

- add the arcgis-mcp-bridge console entry point
- prepare server.json for Official MCP Registry publication
- add the uvx runtime hint and explicit PyPI metadata
- document releases 0.6.3, 0.6.4, and 0.6.5
- clarify Windows and licensed ArcGIS Pro runtime requirements

## Validation

- validated server.json
- synchronized all development extras from uv.lock
- verified the built wheel in a clean isolated environment
- verified all three packaged console executables
- ran Ruff
- ran mypy strict
- passed all 86 tests
- built the wheel and source distribution

## Recovery points

- stable release: v0.6.3
- stable tree snapshot: snapshot/v0.6.3
- pre-v0.6.5 main release: v0.6.4