### PR TITLE
fix: satisfy MCP Registry metadata validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/)
 
+## [0.6.6] - 2026-07-31
+
+### Fixed
+
+- Shortened the Official MCP Registry description to satisfy its
+  100-character validation limit.
+- Aligned the Registry server and PyPI package metadata at version `0.6.6`.
+
+[0.6.6]: https://github.com/muend/arcgis-mcp-bridge/compare/v0.6.5...v0.6.6
+
 ## [0.6.5] - 2026-07-30
 
 ### Added

--- a/server.json
+++ b/server.json
@@ -2,18 +2,18 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.muend/arcgis-mcp-bridge",
   "title": "ArcGIS MCP Bridge",
-  "description": "A secure, local-first MCP server exposing ArcGIS Pro's ArcPy engine on Windows. Requires a licensed ArcGIS Pro installation and a provisioned ArcGIS Python environment.",
+  "description": "Secure local-first MCP server for licensed ArcGIS Pro and ArcPy on Windows.",
   "repository": {
     "url": "https://github.com/muend/arcgis-mcp-bridge",
     "source": "github"
   },
-  "version": "0.6.5",
+  "version": "0.6.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "arcgis-mcp-bridge",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

- shorten the Official MCP Registry description to satisfy its 100-character limit
- advance the Registry server and PyPI package metadata to version 0.6.6
- document the Registry validation fix in the changelog

## Validation

- validated server.json
- confirmed the description is 75 characters
- confirmed server and package versions are both 0.6.6
- ran Ruff
- ran mypy strict
- passed all 86 tests